### PR TITLE
Infer TPR kind and group

### DIFF
--- a/tpr/error.go
+++ b/tpr/error.go
@@ -11,6 +11,13 @@ func IsInvalidConfig(err error) bool {
 	return errgo.Cause(err) == invalidConfigError
 }
 
+var unexpectedlyShortResourceNameError = errgo.New("unexpectedly short resource name")
+
+// IsUnexpectedlyShortResourceName asserts unexpectedlyShortResourceNameError.
+func IsUnexpectedlyShortResourceName(err error) bool {
+	return errgo.Cause(err) == unexpectedlyShortResourceNameError
+}
+
 var tprInitTimeoutError = errgo.New("initialization timeout")
 
 // IsTPRInitTimeout asserts tprInitTimeoutError.

--- a/tpr/kind.go
+++ b/tpr/kind.go
@@ -11,7 +11,7 @@ import (
 	https://github.com/kubernetes/kubernetes/blob/6a4d5cd7cc58e28c20ca133dab7b0e9e56192fe3/pkg/registry/extensions/thirdpartyresourcedata/util.go
 */
 
-// extractKindAndGroup extracts kind and group from a name. For details see
+// extractKindAndGroup extracts kind and group from a name. For details see the
 // Config.Name godoc.
 func extractKindAndGroup(name string) (kind, group string, err error) {
 	parts := strings.Split(name, ".")
@@ -22,8 +22,8 @@ func extractKindAndGroup(name string) (kind, group string, err error) {
 	// kind
 	kindPart := parts[0]
 	toUpper := true
-	for ix := range kindPart {
-		char := kindPart[ix]
+	for i := range kindPart {
+		char := kindPart[i]
 		if toUpper {
 			kind = kind + string([]byte{(char - 32)})
 			toUpper = false

--- a/tpr/kind.go
+++ b/tpr/kind.go
@@ -13,7 +13,7 @@ import (
 
 // extractKindAndGroup extracts kind and group from a name. For details see
 // Config.Name godoc.
-func extractKindAndGroup(name string) (kind string, group string, err error) {
+func extractKindAndGroup(name string) (kind, group string, err error) {
 	parts := strings.Split(name, ".")
 	if len(parts) < 3 {
 		return "", "", microerror.MaskAnyf(unexpectedlyShortResourceNameError, "%s, expected at least <kind>.<domain>.<tld>", name)

--- a/tpr/kind.go
+++ b/tpr/kind.go
@@ -1,0 +1,40 @@
+package tpr
+
+import (
+	"strings"
+
+	microerror "github.com/giantswarm/microkit/error"
+)
+
+/*
+	Code based on:
+	https://github.com/kubernetes/kubernetes/blob/6a4d5cd7cc58e28c20ca133dab7b0e9e56192fe3/pkg/registry/extensions/thirdpartyresourcedata/util.go
+*/
+
+// extractKindAndGroup extracts kind and group from a name. For details see
+// Config.Name godoc.
+func extractKindAndGroup(name string) (kind string, group string, err error) {
+	parts := strings.Split(name, ".")
+	if len(parts) < 3 {
+		return "", "", microerror.MaskAnyf(unexpectedlyShortResourceNameError, "%s, expected at least <kind>.<domain>.<tld>", name)
+	}
+
+	// kind
+	kindPart := parts[0]
+	toUpper := true
+	for ix := range kindPart {
+		char := kindPart[ix]
+		if toUpper {
+			kind = kind + string([]byte{(char - 32)})
+			toUpper = false
+		} else if char == '-' {
+			toUpper = true
+		} else {
+			kind = kind + string([]byte{char})
+		}
+	}
+
+	group = strings.Join(parts[1:], ".")
+
+	return
+}

--- a/tpr/kind_test.go
+++ b/tpr/kind_test.go
@@ -9,35 +9,35 @@ import (
 
 func TestExtractKindAndGroup(t *testing.T) {
 	tests := []struct {
-		Input         string
-		ExpectedKind  string
-		ExpectedGroup string
-		ExpectedError error
+		name          string
+		expectedKind  string
+		expectedGroup string
+		expectedError error
 	}{
 		{
-			Input:         "foo.company.com",
-			ExpectedKind:  "Foo",
-			ExpectedGroup: "company.com",
+			name:          "foo.company.com",
+			expectedKind:  "Foo",
+			expectedGroup: "company.com",
 		},
 		{
-			Input:         "cron-tab.company.com",
-			ExpectedKind:  "CronTab",
-			ExpectedGroup: "company.com",
+			name:          "cron-tab.company.com",
+			expectedKind:  "CronTab",
+			expectedGroup: "company.com",
 		},
 		{
-			Input:         "foo",
-			ExpectedError: unexpectedlyShortResourceNameError,
+			name:          "foo",
+			expectedError: unexpectedlyShortResourceNameError,
 		},
 		{
-			Input:         "foo.company",
-			ExpectedError: unexpectedlyShortResourceNameError,
+			name:          "foo.company",
+			expectedError: unexpectedlyShortResourceNameError,
 		},
 	}
 
-	for i, tt := range tests {
-		kind, group, err := extractKindAndGroup(tt.Input)
-		assert.Equal(t, tt.ExpectedError, errgo.Cause(err), "#%d", i)
-		assert.Equal(t, tt.ExpectedKind, kind, "#%d", i)
-		assert.Equal(t, tt.ExpectedGroup, group, "#%d", i)
+	for i, tc := range tests {
+		kind, group, err := extractKindAndGroup(tc.name)
+		assert.Equal(t, tc.expectedError, errgo.Cause(err), "#%d", i)
+		assert.Equal(t, tc.expectedKind, kind, "#%d", i)
+		assert.Equal(t, tc.expectedGroup, group, "#%d", i)
 	}
 }

--- a/tpr/kind_test.go
+++ b/tpr/kind_test.go
@@ -1,0 +1,43 @@
+package tpr
+
+import (
+	"testing"
+
+	"github.com/juju/errgo"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractKindAndGroup(t *testing.T) {
+	tests := []struct {
+		Input         string
+		ExpectedKind  string
+		ExpectedGroup string
+		ExpectedError error
+	}{
+		{
+			Input:         "foo.company.com",
+			ExpectedKind:  "Foo",
+			ExpectedGroup: "company.com",
+		},
+		{
+			Input:         "cron-tab.company.com",
+			ExpectedKind:  "CronTab",
+			ExpectedGroup: "company.com",
+		},
+		{
+			Input:         "foo",
+			ExpectedError: unexpectedlyShortResourceNameError,
+		},
+		{
+			Input:         "foo.company",
+			ExpectedError: unexpectedlyShortResourceNameError,
+		},
+	}
+
+	for i, tt := range tests {
+		kind, group, err := extractKindAndGroup(tt.Input)
+		assert.Equal(t, tt.ExpectedError, errgo.Cause(err), "#%d", i)
+		assert.Equal(t, tt.ExpectedKind, kind, "#%d", i)
+		assert.Equal(t, tt.ExpectedGroup, group, "#%d", i)
+	}
+}

--- a/tpr/tpr.go
+++ b/tpr/tpr.go
@@ -53,6 +53,7 @@ type TPR struct {
 	kind        string // see Config.Name
 	group       string // see Config.Name
 	version     string
+	apiVersion  string // apiVersion is group/version
 	description string
 
 	endpoint string
@@ -84,6 +85,7 @@ func New(config Config) (*TPR, error) {
 		kind:        kind,
 		group:       group,
 		version:     config.Version,
+		apiVersion:  group + "/" + config.Version,
 		description: config.Description,
 
 		endpoint: fmt.Sprintf("/apis/%s/%s/%ss", group, config.Version, kind),
@@ -91,11 +93,15 @@ func New(config Config) (*TPR, error) {
 	return tpr, nil
 }
 
-// Name returns TPR name provided with Config.Name.
-func (t *TPR) Name() string { return t.name }
-
 // Kind returns TPR kind extracted from Name. See Config.Name godoc for details.
 func (t *TPR) Kind() string { return t.kind }
+
+// APIVersion returns TPR APIVersion created from group and version. It takes
+// format <group>/<version>. See Config.Name and Config.Version for details.
+func (t *TPR) APIVersion() string { return t.apiVersion }
+
+// Name returns TPR name provided with Config.Name.
+func (t *TPR) Name() string { return t.name }
 
 // Group returns TPR group extracted from Name. See Config.Name godoc for details.
 func (t *TPR) Group() string { return t.group }

--- a/tpr/tpr.go
+++ b/tpr/tpr.go
@@ -26,16 +26,14 @@ type Config struct {
 
 	// Settings.
 
-	// Name of the kind of ThirdPartyObjects. It should be in lower case
-	// and hyphen delimited. Kind names will be converted to CamelCase
-	// when creating ThirdPartyObjects. Hyphens in the kind are assumed to
-	// be word breaks. For instance the kind camel-case would be converted
-	// to CamelCase but camelcase would be converted to Camelcase.
+	// Name takes the form <kind>.<domain>. The domain is also known as
+	// a group. You are expected to provide a unique kind and group name in
+	// order to avoid conflicts with other ThirdPartyResource objects. Kind
+	// names will be converted to CamelCase when creating instances of the
+	// ThirdPartyResource.  Hyphens in the kind are assumed to be word
+	// breaks. For instance the kind camel-case would be converted to
+	// CamelCase but camelcase would be converted to Camelcase.
 	Name string
-
-	// Domain of ThirdPartyResource, e.g. example.com. Along with Name must
-	// create an unique pair.
-	Domain string
 
 	// Version is API version, e.g. v1. When creating ThirdPartyObjects will be
 	// prefixed with Domain, e.g. example.com/v1.
@@ -51,13 +49,13 @@ type Config struct {
 type TPR struct {
 	clientset kubernetes.Interface
 
-	name          string
-	group         string
-	version       string
-	description   string
-	qualifiedName string // name.group
+	name        string // see Config.Name
+	kind        string // see Config.Name
+	group       string // see Config.Name
+	version     string
+	description string
 
-	endpointList string
+	endpoint string
 }
 
 func New(config Config) (*TPR, error) {
@@ -67,9 +65,6 @@ func New(config Config) (*TPR, error) {
 	if config.Name == "" {
 		return nil, microerror.MaskAnyf(invalidConfigError, "name must not be empty")
 	}
-	if config.Domain == "" {
-		return nil, microerror.MaskAnyf(invalidConfigError, "group must not be empty")
-	}
 	if config.Version == "" {
 		return nil, microerror.MaskAnyf(invalidConfigError, "version must not be empty")
 	}
@@ -77,19 +72,33 @@ func New(config Config) (*TPR, error) {
 		return nil, microerror.MaskAnyf(invalidConfigError, "description must not be empty")
 	}
 
+	kind, group, err := extractKindAndGroup(config.Name)
+	if err != nil {
+		return nil, microerror.MaskAny(err)
+	}
+
 	tpr := &TPR{
 		clientset: config.Clientset,
 
-		name:          config.Name,
-		group:         config.Domain,
-		version:       config.Version,
-		description:   config.Description,
-		qualifiedName: config.Name + "." + config.Domain,
+		name:        config.Name,
+		kind:        kind,
+		group:       group,
+		version:     config.Version,
+		description: config.Description,
 
-		endpointList: fmt.Sprintf("/apis/%s/%s/%ss", config.Domain, config.Version, config.Name),
+		endpoint: fmt.Sprintf("/apis/%s/%s/%ss", group, config.Version, kind),
 	}
 	return tpr, nil
 }
+
+// Name returns TPR name provided with Config.Name.
+func (t *TPR) Name() string { return t.name }
+
+// Kind returns TPR kind extracted from Name. See Config.Name godoc for details.
+func (t *TPR) Kind() string { return t.kind }
+
+// Group returns TPR group extracted from Name. See Config.Name godoc for details.
+func (t *TPR) Group() string { return t.group }
 
 // CreateAndWait creates a TPR and waits till it is initialized in the cluster.
 func (t *TPR) CreateAndWait() error {
@@ -104,11 +113,11 @@ func (t *TPR) CreateAndWait() error {
 func (t *TPR) CreateAndWaitBackOff(initBackOff backoff.BackOff) error {
 	err := t.create()
 	if err != nil {
-		return microerror.MaskAnyf(err, "creating TPR %s", t.qualifiedName)
+		return microerror.MaskAnyf(err, "creating TPR %s", t.name)
 	}
 	err = t.waitInit(initBackOff)
 	if err != nil {
-		return microerror.MaskAnyf(err, "waiting for TPR %s initialization", t.qualifiedName)
+		return microerror.MaskAnyf(err, "waiting for TPR %s initialization", t.name)
 	}
 	return nil
 }
@@ -118,7 +127,7 @@ func (t *TPR) CreateAndWaitBackOff(initBackOff backoff.BackOff) error {
 func (t *TPR) create() error {
 	tpr := &v1beta1.ThirdPartyResource{
 		ObjectMeta: v1.ObjectMeta{
-			Name: t.qualifiedName,
+			Name: t.name,
 		},
 		Versions: []v1beta1.APIVersion{
 			{Name: t.version},
@@ -128,14 +137,14 @@ func (t *TPR) create() error {
 
 	_, err := t.clientset.ExtensionsV1beta1().ThirdPartyResources().Create(tpr)
 	if err != nil && !errors.IsAlreadyExists(err) {
-		return microerror.MaskAnyf(err, "creating TPR %s", t.qualifiedName)
+		return microerror.MaskAnyf(err, "creating TPR %s", t.name)
 	}
 	return nil
 }
 
 func (t *TPR) waitInit(retry backoff.BackOff) error {
 	op := func() error {
-		_, err := t.clientset.CoreV1().RESTClient().Get().RequestURI(t.endpointList).DoRaw()
+		_, err := t.clientset.CoreV1().RESTClient().Get().RequestURI(t.endpoint).DoRaw()
 		return err
 	}
 
@@ -144,5 +153,5 @@ func (t *TPR) waitInit(retry backoff.BackOff) error {
 	if errors.IsNotFound(err) {
 		err = tprInitTimeoutError
 	}
-	return microerror.MaskAnyf(err, "requesting TPR %s", t.qualifiedName)
+	return microerror.MaskAnyf(err, "requesting TPR %s", t.name)
 }

--- a/tpr/tpr.go
+++ b/tpr/tpr.go
@@ -92,19 +92,19 @@ func New(config Config) (*TPR, error) {
 	return tpr, nil
 }
 
-// Kind returns TPR kind extracted from Name. Useful when creating
+// Kind returns a TPR kind extracted from Name. Useful when creating
 // ThirdPartyObjects. See Config.Name godoc for details.
 func (t *TPR) Kind() string { return t.kind }
 
-// APIVersion returns TPR APIVersion created from group and version. It takes
+// APIVersion returns a TPR APIVersion created from group and version. It takes
 // format <group>/<version>. Useful for creating ThirdPartyObjects. See
 // Config.Name and Config.Version for details.
 func (t *TPR) APIVersion() string { return t.apiVersion }
 
-// Name returns TPR name provided with Config.Name.
+// Name returns a TPR name provided with Config.Name.
 func (t *TPR) Name() string { return t.name }
 
-// Group returns TPR group extracted from Name. See Config.Name godoc for details.
+// Group returns a TPR group extracted from Name. See Config.Name godoc for details.
 func (t *TPR) Group() string { return t.group }
 
 // CreateAndWait creates a TPR and waits till it is initialized in the cluster.

--- a/tpr/tpr.go
+++ b/tpr/tpr.go
@@ -26,17 +26,16 @@ type Config struct {
 
 	// Settings.
 
-	// Name takes the form <kind>.<domain>. The domain is also known as
-	// a group. You are expected to provide a unique kind and group name in
-	// order to avoid conflicts with other ThirdPartyResource objects. Kind
-	// names will be converted to CamelCase when creating instances of the
-	// ThirdPartyResource.  Hyphens in the kind are assumed to be word
+	// Name takes the form <kind>.<group> (Note: The group is also called
+	// a domain). You are expected to provide a unique kind and group name
+	// in order to avoid conflicts with other ThirdPartyResource objects.
+	// Kind names will be converted to CamelCase when creating instances of
+	// the ThirdPartyResource.  Hyphens in the kind are assumed to be word
 	// breaks. For instance the kind camel-case would be converted to
 	// CamelCase but camelcase would be converted to Camelcase.
 	Name string
 
-	// Version is API version, e.g. v1. When creating ThirdPartyObjects will be
-	// prefixed with Domain, e.g. example.com/v1.
+	// Version is TPR version, e.g. v1.
 	Version string
 
 	// Description is free text description.
@@ -93,11 +92,13 @@ func New(config Config) (*TPR, error) {
 	return tpr, nil
 }
 
-// Kind returns TPR kind extracted from Name. See Config.Name godoc for details.
+// Kind returns TPR kind extracted from Name. Useful when creating
+// ThirdPartyObjects. See Config.Name godoc for details.
 func (t *TPR) Kind() string { return t.kind }
 
 // APIVersion returns TPR APIVersion created from group and version. It takes
-// format <group>/<version>. See Config.Name and Config.Version for details.
+// format <group>/<version>. Useful for creating ThirdPartyObjects. See
+// Config.Name and Config.Version for details.
 func (t *TPR) APIVersion() string { return t.apiVersion }
 
 // Name returns TPR name provided with Config.Name.

--- a/tpr/tpr_test.go
+++ b/tpr/tpr_test.go
@@ -20,14 +20,34 @@ func newClientset(nodes int) *fake.Clientset {
 	return clientset
 }
 
+func TestKindAndGroup(t *testing.T) {
+	clientset := newClientset(3)
+
+	config := Config{
+		Clientset: clientset,
+
+		Name:        "test-name.example.com",
+		Version:     "v1test1",
+		Description: "Test Desc",
+	}
+
+	tpr, err := New(config)
+	assert.NoError(t, err, "New")
+
+	assert.Equal(t, config.Name, tpr.Name())
+	assert.Equal(t, "TestName", tpr.Kind())
+	assert.Equal(t, "example.com", tpr.Group())
+
+	// Rest of tests should be covered in extractKindAndGroup tests.
+}
+
 func TestCreateTPR(t *testing.T) {
 	clientset := newClientset(3)
 
 	config := Config{
 		Clientset: clientset,
 
-		Name:        "testname",
-		Domain:      "example.com",
+		Name:        "test-name.example.com",
 		Version:     "v1test1",
 		Description: "Test Desc",
 	}
@@ -44,7 +64,7 @@ func TestCreateTPR(t *testing.T) {
 	resp, err = clientset.ExtensionsV1beta1().ThirdPartyResources().List(v1.ListOptions{})
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(resp.Items))
-	assert.Equal(t, config.Name+"."+config.Domain, resp.Items[0].Name)
+	assert.Equal(t, config.Name, resp.Items[0].Name)
 	assert.Equal(t, 1, len(resp.Items[0].Versions))
 	assert.Equal(t, "v1test1", resp.Items[0].Versions[0].Name)
 	assert.Equal(t, "Test Desc", resp.Items[0].Description)

--- a/tpr/tpr_test.go
+++ b/tpr/tpr_test.go
@@ -34,8 +34,9 @@ func TestKindAndGroup(t *testing.T) {
 	tpr, err := New(config)
 	assert.NoError(t, err, "New")
 
-	assert.Equal(t, config.Name, tpr.Name())
 	assert.Equal(t, "TestName", tpr.Kind())
+	assert.Equal(t, "example.com/v1test1", tpr.APIVersion())
+	assert.Equal(t, config.Name, tpr.Name())
 	assert.Equal(t, "example.com", tpr.Group())
 
 	// Rest of tests should be covered in extractKindAndGroup tests.


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/1483

This change allows passing full name of TPR and extract kind name and group name from it. This is useful for creating TPOs (used in kubernetesd), and also allows creating REST endpoints (used in all operators, and potentially in reconciliation loop).

Next steps is to add pluralization logic and provide methods with TPR resource endpoint and TPR watch endpoint.