### PR TITLE
added DefaultConfig for k8s client

### DIFF
--- a/client/k8s/k8s_test.go
+++ b/client/k8s/k8s_test.go
@@ -2,30 +2,15 @@ package k8s
 
 import (
 	"fmt"
-	"os"
 	"testing"
-
-	"github.com/giantswarm/microkit/logger"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestGetRawClientConfig(t *testing.T) {
-	var err error
-	var newLogger logger.Logger
-
-	{
-		loggerConfig := logger.DefaultConfig()
-		loggerConfig.IOWriter = os.Stdout
-		newLogger, err = logger.New(loggerConfig)
-		if err != nil {
-			panic(err)
-		}
-	}
-
+	caFile := "/var/run/kubernetes/server-ca.crt"
 	crtFile := "/var/run/kubernetes/client-admin.crt"
 	keyFile := "/var/run/kubernetes/client-admin.key"
-	caFile := "/var/run/kubernetes/server-ca.crt"
 
 	tests := []struct {
 		name            string
@@ -58,18 +43,14 @@ func TestGetRawClientConfig(t *testing.T) {
 			expectedAddress: "invalid-host",
 		},
 	}
-	for _, tc := range tests {
-		config := Config{
-			Logger: newLogger,
 
-			Address:   tc.expectedAddress,
-			InCluster: tc.inCluster,
-			TLS: TLSClientConfig{
-				CAFile:  caFile,
-				CrtFile: crtFile,
-				KeyFile: keyFile,
-			},
-		}
+	for _, tc := range tests {
+		config := DefaultConfig()
+		config.Address = tc.expectedAddress
+		config.InCluster = tc.inCluster
+		config.TLS.CAFile = caFile
+		config.TLS.CrtFile = crtFile
+		config.TLS.KeyFile = keyFile
 
 		rawClientConfig, err := getRawClientConfig(config)
 		if tc.expectedError {


### PR DESCRIPTION
IMO whenever configuration is provided we should always provide a way of gathering default configuration. This eases development, testing and ensures package specific configuration is given on purpose by the maintainer, because he knows the package best. I as a user do not want to care about all the little details all the times. This PR adds a `DefaultConfig` method to the k8s client package, which should always be used whenever a new client is initialized. 