### PR TITLE
pin go-restful

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 0a15a071a0511453b68cb4df3a981fcca375a5248e899aa555830cfa9a6abdcb
-updated: 2017-07-13T14:14:35.700607678+02:00
+hash: 7e78cafb8e1142406aa70bb4af310de4dc8a5a0dffc3a46b3d187ca3202b69fa
+updated: 2017-07-17T15:40:53.305474431+02:00
 imports:
 - name: github.com/cenkalti/backoff
   version: 32cd0c5b3aef12c76ed64aaf678f6c79736be7dc

--- a/glide.yaml
+++ b/glide.yaml
@@ -14,6 +14,9 @@ import:
 # apimachinery is pinned to the version client-go uses.
 - package: k8s.io/apimachinery
   version: 85ace5365f33b16fc735c866a12e3c765b9700f2
+# go-restful is pinned to the version client-go uses.
+- package: github.com/emicklei/go-restful
+  version: 09691a3b6378b740595c1002f40c34dd5f218a22
 testImport:
 - package: github.com/stretchr/testify
   version: v1.1.4


### PR DESCRIPTION
This is to avoid conflicts and make vendor updates experience smoother.