### PR TITLE
ensure Prometheus namespace and subsystem are camel case

### DIFF
--- a/framework/metricsresource/camel_case.go
+++ b/framework/metricsresource/camel_case.go
@@ -1,0 +1,19 @@
+package metricsresource
+
+import (
+	"bytes"
+	"regexp"
+)
+
+var camelCaseRegex = regexp.MustCompile("[0-9A-Za-z]+")
+
+func toCamelCase(src string) string {
+	byteSrc := []byte(src)
+	chunks := camelCaseRegex.FindAll(byteSrc, -1)
+	for idx, val := range chunks {
+		if idx > 0 {
+			chunks[idx] = bytes.Title(val)
+		}
+	}
+	return string(bytes.Join(chunks, nil))
+}

--- a/framework/metricsresource/camel_case_test.go
+++ b/framework/metricsresource/camel_case_test.go
@@ -1,0 +1,42 @@
+package metricsresource
+
+import (
+	"testing"
+)
+
+// Test_MetricsResource_toCamelCase ensures the resource's Prometheus related
+// configurations are properly formatted as expected.
+func Test_MetricsResource_toCamelCase(t *testing.T) {
+	testCases := []struct {
+		InputString    string
+		ExpectedString string
+	}{
+		{
+			InputString:    "foo-bar",
+			ExpectedString: "fooBar",
+		},
+		{
+			InputString:    "foo+bar",
+			ExpectedString: "fooBar",
+		},
+		{
+			InputString:    "foo bar",
+			ExpectedString: "fooBar",
+		},
+		{
+			InputString:    "foo_bar",
+			ExpectedString: "fooBar",
+		},
+		{
+			InputString:    "fooBar",
+			ExpectedString: "fooBar",
+		},
+	}
+
+	for i, tc := range testCases {
+		output := toCamelCase(tc.InputString)
+		if output != tc.ExpectedString {
+			t.Fatal("test", i+1, "expected", tc.ExpectedString, "got", output)
+		}
+	}
+}

--- a/framework/metricsresource/resource.go
+++ b/framework/metricsresource/resource.go
@@ -66,8 +66,8 @@ func New(config Config) (*Resource, error) {
 	{
 		operationDuration = prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
-				Namespace: config.Namespace,
-				Subsystem: config.Subsystem,
+				Namespace: toCamelCase(config.Namespace),
+				Subsystem: toCamelCase(config.Subsystem),
 				Name:      "operatorkit_framework_operation_duration_milliseconds",
 				Help:      "Time taken to process a single reconciliation operation.",
 			},
@@ -75,8 +75,8 @@ func New(config Config) (*Resource, error) {
 		)
 		operationTotal = prometheus.NewCounterVec(
 			prometheus.CounterOpts{
-				Namespace: config.Namespace,
-				Subsystem: config.Subsystem,
+				Namespace: toCamelCase(config.Namespace),
+				Subsystem: toCamelCase(config.Subsystem),
 				Name:      "operatorkit_framework_operation_total",
 				Help:      "Number of processed reconciliation operations.",
 			},


### PR DESCRIPTION
This PR prevents the following panic. We recently added the metrics resource which is configured with the name of the operator. The operators have dashes in their names which Prometheus does not like as namespace/subsystem. 

```
panic: descriptor Desc{fqName: "ingress-operator_configmap_operatorkit_framework_operation_duration_milliseconds", help: "Time taken to process a single reconciliation operation.", constLabels: {}, variableLabels: [operation]} is invalid: "ingress-operator_configmap_operatorkit_framework_operation_duration_milliseconds" is not a valid metric name

goroutine 1 [running]:
github.com/giantswarm/ingress-operator/vendor/github.com/prometheus/client_golang/prometheus.(*Registry).MustRegister(0xc420012ec0, 0xc4202d7d10, 0x1, 0x1)
	/Users/xh3b4sd/go/src/github.com/giantswarm/ingress-operator/vendor/github.com/prometheus/client_golang/prometheus/registry.go:404 +0x92
github.com/giantswarm/ingress-operator/vendor/github.com/prometheus/client_golang/prometheus.MustRegister(0xc4202d7d10, 0x1, 0x1)
...
```