### PR TITLE
added resource cancelation support

### DIFF
--- a/framework/cancelercontext/canceler_context.go
+++ b/framework/cancelercontext/canceler_context.go
@@ -1,0 +1,28 @@
+// Package cancelercontext stores and accesses the HTTP Authorization precondition
+// context.Context.
+package cancelercontext
+
+import (
+	"context"
+)
+
+// key is an unexported type for keys defined in this package. This prevents
+// collisions with keys defined in other packages.
+type key string
+
+// cancelKey is the key for cancel values in context.Context. Clients use
+// cancelercontext.NewContext and cancelercontext.FromContext instead of using this
+// key directly.
+var cancelKey key = "canceler"
+
+// NewContext returns a new context.Context that carries value v.
+func NewContext(ctx context.Context, v chan struct{}) context.Context {
+	return context.WithValue(ctx, cancelKey, v)
+}
+
+// FromContext returns the HTTP Authorization preconditionx, if
+// any.
+func FromContext(ctx context.Context) (chan struct{}, bool) {
+	v, ok := ctx.Value(cancelKey).(chan struct{})
+	return v, ok
+}

--- a/framework/cancelercontext/canceler_context.go
+++ b/framework/cancelercontext/canceler_context.go
@@ -26,3 +26,22 @@ func FromContext(ctx context.Context) (chan struct{}, bool) {
 	v, ok := ctx.Value(cancelKey).(chan struct{})
 	return v, ok
 }
+
+// IsCanceled checks whether the given context obtains information about the
+// canceler as defined in this package, if any canceler is present.
+//
+// NOTE that the canceler, if any found, must be buffered. Otherwise it will
+// block until a signal is received.
+func IsCanceled(ctx context.Context) bool {
+	canceler, cancelerExists := FromContext(ctx)
+	if cancelerExists {
+		select {
+		case <-canceler:
+			return true
+		default:
+			// fall thorugh
+		}
+	}
+
+	return false
+}

--- a/framework/framework.go
+++ b/framework/framework.go
@@ -161,31 +161,33 @@ func ProcessCreate(ctx context.Context, obj interface{}, resources []Resource) e
 	}
 
 	for _, r := range resources {
-		canceler, cancelerExists := cancelercontext.FromContext(ctx)
-		if cancelerExists {
-			select {
-			case <-canceler:
-				return nil
-			default:
-				// fall thorugh
-			}
+		if cancelercontext.IsCanceled(ctx) {
+			return nil
 		}
-
 		currentState, err := r.GetCurrentState(ctx, obj)
 		if err != nil {
 			return microerror.Mask(err)
 		}
 
+		if cancelercontext.IsCanceled(ctx) {
+			return nil
+		}
 		desiredState, err := r.GetDesiredState(ctx, obj)
 		if err != nil {
 			return microerror.Mask(err)
 		}
 
+		if cancelercontext.IsCanceled(ctx) {
+			return nil
+		}
 		createState, err := r.GetCreateState(ctx, obj, currentState, desiredState)
 		if err != nil {
 			return microerror.Mask(err)
 		}
 
+		if cancelercontext.IsCanceled(ctx) {
+			return nil
+		}
 		err = r.ProcessCreateState(ctx, obj, createState)
 		if err != nil {
 			return microerror.Mask(err)
@@ -217,31 +219,33 @@ func ProcessDelete(ctx context.Context, obj interface{}, resources []Resource) e
 	}
 
 	for _, r := range resources {
-		canceler, cancelerExists := cancelercontext.FromContext(ctx)
-		if cancelerExists {
-			select {
-			case <-canceler:
-				return nil
-			default:
-				// fall thorugh
-			}
+		if cancelercontext.IsCanceled(ctx) {
+			return nil
 		}
-
 		currentState, err := r.GetCurrentState(ctx, obj)
 		if err != nil {
 			return microerror.Mask(err)
 		}
 
+		if cancelercontext.IsCanceled(ctx) {
+			return nil
+		}
 		desiredState, err := r.GetDesiredState(ctx, obj)
 		if err != nil {
 			return microerror.Mask(err)
 		}
 
+		if cancelercontext.IsCanceled(ctx) {
+			return nil
+		}
 		deleteState, err := r.GetDeleteState(ctx, obj, currentState, desiredState)
 		if err != nil {
 			return microerror.Mask(err)
 		}
 
+		if cancelercontext.IsCanceled(ctx) {
+			return nil
+		}
 		err = r.ProcessDeleteState(ctx, obj, deleteState)
 		if err != nil {
 			return microerror.Mask(err)
@@ -274,41 +278,49 @@ func ProcessUpdate(ctx context.Context, obj interface{}, resources []Resource) e
 	}
 
 	for _, r := range resources {
-		canceler, cancelerExists := cancelercontext.FromContext(ctx)
-		if cancelerExists {
-			select {
-			case <-canceler:
-				return nil
-			default:
-				// fall thorugh
-			}
+		if cancelercontext.IsCanceled(ctx) {
+			return nil
 		}
-
 		currentState, err := r.GetCurrentState(ctx, obj)
 		if err != nil {
 			return microerror.Mask(err)
 		}
 
+		if cancelercontext.IsCanceled(ctx) {
+			return nil
+		}
 		desiredState, err := r.GetDesiredState(ctx, obj)
 		if err != nil {
 			return microerror.Mask(err)
 		}
 
+		if cancelercontext.IsCanceled(ctx) {
+			return nil
+		}
 		createState, deleteState, updateState, err := r.GetUpdateState(ctx, obj, currentState, desiredState)
 		if err != nil {
 			return microerror.Mask(err)
 		}
 
+		if cancelercontext.IsCanceled(ctx) {
+			return nil
+		}
 		err = r.ProcessCreateState(ctx, obj, createState)
 		if err != nil {
 			return microerror.Mask(err)
 		}
 
+		if cancelercontext.IsCanceled(ctx) {
+			return nil
+		}
 		err = r.ProcessDeleteState(ctx, obj, deleteState)
 		if err != nil {
 			return microerror.Mask(err)
 		}
 
+		if cancelercontext.IsCanceled(ctx) {
+			return nil
+		}
 		err = r.ProcessUpdateState(ctx, obj, updateState)
 		if err != nil {
 			return microerror.Mask(err)

--- a/framework/framework_test.go
+++ b/framework/framework_test.go
@@ -8,120 +8,484 @@ import (
 	"github.com/giantswarm/operatorkit/framework/cancelercontext"
 )
 
-// Test_Framework_ProcessCreate_NoResource ensures there is an error thrown when
-// executing ProcessCreate without having any resources provided.
-func Test_Framework_ProcessCreate_NoResource(t *testing.T) {
-	err := ProcessCreate(context.TODO(), nil, nil)
-	if !IsExecutionFailed(err) {
-		t.Fatal("expected", true, "got", false)
-	}
-}
-
-// Test_Framework_ProcessDelete_NoResource ensures there is an error thrown when
-// executing ProcessDelete without having any resources provided.
-func Test_Framework_ProcessDelete_NoResource(t *testing.T) {
-	err := ProcessDelete(context.TODO(), nil, nil)
-	if !IsExecutionFailed(err) {
-		t.Fatal("expected", true, "got", false)
-	}
-}
-
-// Test_Framework_ProcessUpdate_NoResource ensures there is an error thrown when
-// executing ProcessUpdate without having any resources provided.
-func Test_Framework_ProcessUpdate_NoResource(t *testing.T) {
-	err := ProcessUpdate(context.TODO(), nil, nil)
-	if !IsExecutionFailed(err) {
-		t.Fatal("expected", true, "got", false)
-	}
-}
-
 // Test_Framework_ProcessCreate_ResourceOrder ensures the resource's methods are
 // executed as expected when creating resources.
 func Test_Framework_ProcessCreate_ResourceOrder(t *testing.T) {
 	testCases := []struct {
-		Resource      Resource
-		ExpectedOrder []string
-		ErrorMatcher  func(err error) bool
+		ProcessMethod  func(ctx context.Context, obj interface{}, rs []Resource) error
+		Ctx            context.Context
+		Resources      []Resource
+		ExpectedOrders [][]string
+		ErrorMatcher   func(err error) bool
 	}{
+		// Test 1 ensures ProcessCreate returns an error in case no resources are
+		// provided.
 		{
-			Resource: &testResource{},
-			ExpectedOrder: []string{
-				"GetCurrentState",
-				"GetDesiredState",
-				"GetCreateState",
-				"ProcessCreateState",
+			ProcessMethod:  ProcessCreate,
+			Ctx:            context.TODO(),
+			Resources:      nil,
+			ExpectedOrders: nil,
+			ErrorMatcher:   IsExecutionFailed,
+		},
+
+		// Test 2 ensures ProcessCreate executes the steps of a single resource in
+		// the expected order.
+		{
+			ProcessMethod: ProcessCreate,
+			Ctx:           context.TODO(),
+			Resources: []Resource{
+				&testResource{},
+			},
+			ExpectedOrders: [][]string{
+				{
+					"GetCurrentState",
+					"GetDesiredState",
+					"GetCreateState",
+					"ProcessCreateState",
+				},
+			},
+			ErrorMatcher: nil,
+		},
+
+		// Test 3 ensures ProcessCreate executes the steps of multile resources in
+		// the expected order.
+		{
+			ProcessMethod: ProcessCreate,
+			Ctx:           context.TODO(),
+			Resources: []Resource{
+				&testResource{},
+				&testResource{},
+			},
+			ExpectedOrders: [][]string{
+				{
+					"GetCurrentState",
+					"GetDesiredState",
+					"GetCreateState",
+					"ProcessCreateState",
+				},
+				{
+					"GetCurrentState",
+					"GetDesiredState",
+					"GetCreateState",
+					"ProcessCreateState",
+				},
+			},
+			ErrorMatcher: nil,
+		},
+
+		// Test 4 ensures ProcessCreate executes the steps of a single resource in
+		// the expected order until it gets canceled.
+		{
+			ProcessMethod: ProcessCreate,
+			Ctx:           cancelercontext.NewContext(context.Background(), make(chan struct{}, 1)),
+			Resources: []Resource{
+				&testResource{
+					CancelingStep: "GetCurrentState",
+				},
+			},
+			ExpectedOrders: [][]string{
+				{
+					"GetCurrentState",
+				},
+			},
+			ErrorMatcher: nil,
+		},
+
+		// Test 5 ensures ProcessCreate executes the steps of a single resource in
+		// the expected order even if the resource is canceled while the given
+		// context does not contain a canceler.
+		{
+			ProcessMethod: ProcessCreate,
+			Ctx:           context.TODO(),
+			Resources: []Resource{
+				&testResource{
+					CancelingStep: "GetCurrentState",
+				},
+			},
+			ExpectedOrders: [][]string{
+				{
+					"GetCurrentState",
+					"GetDesiredState",
+					"GetCreateState",
+					"ProcessCreateState",
+				},
+			},
+			ErrorMatcher: nil,
+		},
+
+		// Test 6 ensures ProcessCreate executes the steps of the first resource in
+		// the expected order in case multile resources are given, until the first
+		// resource gets canceled.
+		{
+			ProcessMethod: ProcessCreate,
+			Ctx:           cancelercontext.NewContext(context.Background(), make(chan struct{}, 1)),
+			Resources: []Resource{
+				&testResource{
+					CancelingStep: "GetCreateState",
+				},
+				&testResource{},
+			},
+			ExpectedOrders: [][]string{
+				{
+					"GetCurrentState",
+					"GetDesiredState",
+					"GetCreateState",
+				},
+				nil,
+			},
+			ErrorMatcher: nil,
+		},
+
+		// Test 7 ensures ProcessCreate executes the steps of the first and second resource in
+		// the expected order in case multile resources are given, until the second
+		// resource gets canceled.
+		{
+			ProcessMethod: ProcessCreate,
+			Ctx:           cancelercontext.NewContext(context.Background(), make(chan struct{}, 1)),
+			Resources: []Resource{
+				&testResource{},
+				&testResource{
+					CancelingStep: "GetCreateState",
+				},
+			},
+			ExpectedOrders: [][]string{
+				{
+					"GetCurrentState",
+					"GetDesiredState",
+					"GetCreateState",
+					"ProcessCreateState",
+				},
+				{
+					"GetCurrentState",
+					"GetDesiredState",
+					"GetCreateState",
+				},
+			},
+			ErrorMatcher: nil,
+		},
+
+		// Test 8 ensures ProcessDelete returns an error in case no resources are
+		// provided.
+		{
+			ProcessMethod:  ProcessDelete,
+			Ctx:            context.TODO(),
+			Resources:      nil,
+			ExpectedOrders: nil,
+			ErrorMatcher:   IsExecutionFailed,
+		},
+
+		// Test 9 ensures ProcessDelete executes the steps of a single resource in
+		// the expected order.
+		{
+			ProcessMethod: ProcessDelete,
+			Ctx:           context.TODO(),
+			Resources: []Resource{
+				&testResource{},
+			},
+			ExpectedOrders: [][]string{
+				{
+					"GetCurrentState",
+					"GetDesiredState",
+					"GetDeleteState",
+					"ProcessDeleteState",
+				},
+			},
+			ErrorMatcher: nil,
+		},
+
+		// Test 10 ensures ProcessDelete executes the steps of multile resources in
+		// the expected order.
+		{
+			ProcessMethod: ProcessDelete,
+			Ctx:           context.TODO(),
+			Resources: []Resource{
+				&testResource{},
+				&testResource{},
+			},
+			ExpectedOrders: [][]string{
+				{
+					"GetCurrentState",
+					"GetDesiredState",
+					"GetDeleteState",
+					"ProcessDeleteState",
+				},
+				{
+					"GetCurrentState",
+					"GetDesiredState",
+					"GetDeleteState",
+					"ProcessDeleteState",
+				},
+			},
+			ErrorMatcher: nil,
+		},
+
+		// Test 11 ensures ProcessDelete executes the steps of a single resource in
+		// the expected order until it gets canceled.
+		{
+			ProcessMethod: ProcessDelete,
+			Ctx:           cancelercontext.NewContext(context.Background(), make(chan struct{}, 1)),
+			Resources: []Resource{
+				&testResource{
+					CancelingStep: "GetCurrentState",
+				},
+			},
+			ExpectedOrders: [][]string{
+				{
+					"GetCurrentState",
+				},
+			},
+			ErrorMatcher: nil,
+		},
+
+		// Test 12 ensures ProcessDelete executes the steps of a single resource in
+		// the expected order even if the resource is canceled while the given
+		// context does not contain a canceler.
+		{
+			ProcessMethod: ProcessDelete,
+			Ctx:           context.TODO(),
+			Resources: []Resource{
+				&testResource{
+					CancelingStep: "GetCurrentState",
+				},
+			},
+			ExpectedOrders: [][]string{
+				{
+					"GetCurrentState",
+					"GetDesiredState",
+					"GetDeleteState",
+					"ProcessDeleteState",
+				},
+			},
+			ErrorMatcher: nil,
+		},
+
+		// Test 13 ensures ProcessDelete executes the steps of the first resource in
+		// the expected order in case multile resources are given, until the first
+		// resource gets canceled.
+		{
+			ProcessMethod: ProcessDelete,
+			Ctx:           cancelercontext.NewContext(context.Background(), make(chan struct{}, 1)),
+			Resources: []Resource{
+				&testResource{
+					CancelingStep: "GetDeleteState",
+				},
+				&testResource{},
+			},
+			ExpectedOrders: [][]string{
+				{
+					"GetCurrentState",
+					"GetDesiredState",
+					"GetDeleteState",
+				},
+				nil,
+			},
+			ErrorMatcher: nil,
+		},
+
+		// Test 14 ensures ProcessDelete executes the steps of the first and second resource in
+		// the expected order in case multile resources are given, until the second
+		// resource gets canceled.
+		{
+			ProcessMethod: ProcessDelete,
+			Ctx:           cancelercontext.NewContext(context.Background(), make(chan struct{}, 1)),
+			Resources: []Resource{
+				&testResource{},
+				&testResource{
+					CancelingStep: "GetDeleteState",
+				},
+			},
+			ExpectedOrders: [][]string{
+				{
+					"GetCurrentState",
+					"GetDesiredState",
+					"GetDeleteState",
+					"ProcessDeleteState",
+				},
+				{
+					"GetCurrentState",
+					"GetDesiredState",
+					"GetDeleteState",
+				},
+			},
+			ErrorMatcher: nil,
+		},
+
+		// Test 15 ensures ProcessUpdate returns an error in case no resources are
+		// provided.
+		{
+			ProcessMethod:  ProcessUpdate,
+			Ctx:            context.TODO(),
+			Resources:      nil,
+			ExpectedOrders: nil,
+			ErrorMatcher:   IsExecutionFailed,
+		},
+
+		// Test 16 ensures ProcessUpdate executes the steps of a single resource in
+		// the expected order.
+		{
+			ProcessMethod: ProcessUpdate,
+			Ctx:           context.TODO(),
+			Resources: []Resource{
+				&testResource{},
+			},
+			ExpectedOrders: [][]string{
+				{
+					"GetCurrentState",
+					"GetDesiredState",
+					"GetUpdateState",
+					"ProcessCreateState",
+					"ProcessDeleteState",
+					"ProcessUpdateState",
+				},
+			},
+			ErrorMatcher: nil,
+		},
+
+		// Test 17 ensures ProcessUpdate executes the steps of multile resources in
+		// the expected order.
+		{
+			ProcessMethod: ProcessUpdate,
+			Ctx:           context.TODO(),
+			Resources: []Resource{
+				&testResource{},
+				&testResource{},
+			},
+			ExpectedOrders: [][]string{
+				{
+					"GetCurrentState",
+					"GetDesiredState",
+					"GetUpdateState",
+					"ProcessCreateState",
+					"ProcessDeleteState",
+					"ProcessUpdateState",
+				},
+				{
+					"GetCurrentState",
+					"GetDesiredState",
+					"GetUpdateState",
+					"ProcessCreateState",
+					"ProcessDeleteState",
+					"ProcessUpdateState",
+				},
+			},
+			ErrorMatcher: nil,
+		},
+
+		// Test 18 ensures ProcessUpdate executes the steps of a single resource in
+		// the expected order until it gets canceled.
+		{
+			ProcessMethod: ProcessUpdate,
+			Ctx:           cancelercontext.NewContext(context.Background(), make(chan struct{}, 1)),
+			Resources: []Resource{
+				&testResource{
+					CancelingStep: "GetCurrentState",
+				},
+			},
+			ExpectedOrders: [][]string{
+				{
+					"GetCurrentState",
+				},
+			},
+			ErrorMatcher: nil,
+		},
+
+		// Test 19 ensures ProcessUpdate executes the steps of a single resource in
+		// the expected order even if the resource is canceled while the given
+		// context does not contain a canceler.
+		{
+			ProcessMethod: ProcessUpdate,
+			Ctx:           context.TODO(),
+			Resources: []Resource{
+				&testResource{
+					CancelingStep: "GetCurrentState",
+				},
+			},
+			ExpectedOrders: [][]string{
+				{
+					"GetCurrentState",
+					"GetDesiredState",
+					"GetUpdateState",
+					"ProcessCreateState",
+					"ProcessDeleteState",
+					"ProcessUpdateState",
+				},
+			},
+			ErrorMatcher: nil,
+		},
+
+		// Test 20 ensures ProcessUpdate executes the steps of the first resource in
+		// the expected order in case multile resources are given, until the first
+		// resource gets canceled.
+		{
+			ProcessMethod: ProcessUpdate,
+			Ctx:           cancelercontext.NewContext(context.Background(), make(chan struct{}, 1)),
+			Resources: []Resource{
+				&testResource{
+					CancelingStep: "GetUpdateState",
+				},
+				&testResource{},
+			},
+			ExpectedOrders: [][]string{
+				{
+					"GetCurrentState",
+					"GetDesiredState",
+					"GetUpdateState",
+				},
+				nil,
+			},
+			ErrorMatcher: nil,
+		},
+
+		// Test 21 ensures ProcessUpdate executes the steps of the first and second resource in
+		// the expected order in case multile resources are given, until the second
+		// resource gets canceled.
+		{
+			ProcessMethod: ProcessUpdate,
+			Ctx:           cancelercontext.NewContext(context.Background(), make(chan struct{}, 1)),
+			Resources: []Resource{
+				&testResource{},
+				&testResource{
+					CancelingStep: "GetUpdateState",
+				},
+			},
+			ExpectedOrders: [][]string{
+				{
+					"GetCurrentState",
+					"GetDesiredState",
+					"GetUpdateState",
+					"ProcessCreateState",
+					"ProcessDeleteState",
+					"ProcessUpdateState",
+				},
+				{
+					"GetCurrentState",
+					"GetDesiredState",
+					"GetUpdateState",
+				},
 			},
 			ErrorMatcher: nil,
 		},
 	}
 
 	for i, tc := range testCases {
-		rs := []Resource{
-			tc.Resource,
-		}
-
-		err := ProcessCreate(context.TODO(), nil, rs)
+		err := tc.ProcessMethod(tc.Ctx, nil, tc.Resources)
 		if err != nil {
 			if tc.ErrorMatcher == nil {
-				t.Fatal("expected", "error", "got", err)
-			} else {
-				t.Fatal("expected", nil, "got", err)
+				t.Fatal("test", i+1, "expected", "error matcher", "got", nil)
+			} else if !tc.ErrorMatcher(err) {
+				t.Fatal("test", i+1, "expected", true, "got", false)
+			}
+		} else {
+			if len(tc.Resources) != len(tc.ExpectedOrders) {
+				t.Fatal("test", i+1, "expected", len(tc.ExpectedOrders), "got", len(tc.ExpectedOrders))
+			}
+
+			for j, r := range tc.Resources {
+				if !reflect.DeepEqual(tc.ExpectedOrders[j], r.(*testResource).Order) {
+					t.Fatal("test", i+1, "expected", tc.ExpectedOrders[j], "got", r.(*testResource).Order)
+				}
 			}
 		}
-
-		if !reflect.DeepEqual(tc.ExpectedOrder, tc.Resource.Order) {
-			t.Fatal("expected", tc.ExpectedOrder, "got", tc.Resource.Order)
-		}
-	}
-}
-
-// Test_Framework_ProcessDelete_ResourceOrder ensures the resource's methods are
-// executed as expected when deleting resources.
-func Test_Framework_ProcessDelete_ResourceOrder(t *testing.T) {
-	tr := &testResource{}
-	rs := []Resource{
-		tr,
-	}
-
-	err := ProcessDelete(context.TODO(), nil, rs)
-	if err != nil {
-		t.Fatal("expected", nil, "got", err)
-	}
-
-	e := []string{
-		"GetCurrentState",
-		"GetDesiredState",
-		"GetDeleteState",
-		"ProcessDeleteState",
-	}
-	if !reflect.DeepEqual(e, tr.Order) {
-		t.Fatal("expected", e, "got", tr.Order)
-	}
-}
-
-// Test_Framework_ProcessUpdate_ResourceOrder ensures the resource's methods are
-// executed as expected when updating resources.
-func Test_Framework_ProcessUpdate_ResourceOrder(t *testing.T) {
-	tr := &testResource{}
-	rs := []Resource{
-		tr,
-	}
-
-	err := ProcessUpdate(context.TODO(), nil, rs)
-	if err != nil {
-		t.Fatal("expected", nil, "got", err)
-	}
-
-	e := []string{
-		"GetCurrentState",
-		"GetDesiredState",
-		"GetUpdateState",
-		"ProcessCreateState",
-		"ProcessDeleteState",
-		"ProcessUpdateState",
-	}
-	if !reflect.DeepEqual(e, tr.Order) {
-		t.Fatal("expected", e, "got", tr.Order)
 	}
 }
 


### PR DESCRIPTION
This PR provides resource cancelation using the context dispatched through the resource steps being processed. For a discussion around the initial motivation see also https://gigantic.slack.com/archives/C2MS2VB37/p1505483832000091. See also https://github.com/giantswarm/kvm-operator/pull/182. 