### PR TITLE
added initializer to reconciler framework for custom context setup

### DIFF
--- a/framework/framework.go
+++ b/framework/framework.go
@@ -15,6 +15,13 @@ import (
 // Config represents the configuration used to create a new operator framework.
 type Config struct {
 	// Dependencies.
+
+	// Initializer is to prepare the given context for a single reconciliation
+	// loop. Operators can implement common context packages to enable
+	// communication between resources. These context packages can be set up
+	// within the initializer. The initializer receives the custom object being
+	// reconciled. Information provided by the custom object can be used to
+	// initialize the context.
 	Initializer func(ctx context.Context, obj interface{}) (context.Context, error)
 	Logger      micrologger.Logger
 	Resources   []Resource

--- a/framework/framework.go
+++ b/framework/framework.go
@@ -16,13 +16,13 @@ import (
 type Config struct {
 	// Dependencies.
 
-	// Initializer is to prepare the given context for a single reconciliation
+	// InitCtxFunc is to prepare the given context for a single reconciliation
 	// loop. Operators can implement common context packages to enable
 	// communication between resources. These context packages can be set up
-	// within the initializer. The initializer receives the custom object being
-	// reconciled. Information provided by the custom object can be used to
-	// initialize the context.
-	Initializer func(ctx context.Context, obj interface{}) (context.Context, error)
+	// within the context initializer function. InitCtxFunc receives the custom
+	// object being reconciled as second argument. Information provided by the
+	// custom object can be used to initialize the context.
+	InitCtxFunc func(ctx context.Context, obj interface{}) (context.Context, error)
 	Logger      micrologger.Logger
 	Resources   []Resource
 }
@@ -32,7 +32,7 @@ type Config struct {
 func DefaultConfig() Config {
 	return Config{
 		// Dependencies.
-		Initializer: nil,
+		InitCtxFunc: nil,
 		Logger:      nil,
 		Resources:   nil,
 	}
@@ -60,7 +60,7 @@ func New(config Config) (*Framework, error) {
 
 	newFramework := &Framework{
 		// Dependencies.
-		initializer: config.Initializer,
+		initializer: config.InitCtxFunc,
 		logger:      config.Logger,
 		resources:   config.Resources,
 

--- a/framework/framework_initializer_test.go
+++ b/framework/framework_initializer_test.go
@@ -8,23 +8,23 @@ import (
 	"github.com/giantswarm/micrologger/microloggertest"
 )
 
-func Test_Framework_Initializer_AddFunc(t *testing.T) {
+func Test_Framework_InitCtxFunc_AddFunc(t *testing.T) {
 	testCases := []struct {
 		CustomObject  interface{}
-		Initializer   func(ctx context.Context, obj interface{}) (context.Context, error)
+		InitCtxFunc   func(ctx context.Context, obj interface{}) (context.Context, error)
 		ExpectedOrder []string
 	}{
 		{
 			CustomObject: nil,
-			Initializer: func(ctx context.Context, obj interface{}) (context.Context, error) {
+			InitCtxFunc: func(ctx context.Context, obj interface{}) (context.Context, error) {
 				return ctx, nil
 			},
 			ExpectedOrder: nil,
 		},
 		{
 			CustomObject: nil,
-			Initializer: func(ctx context.Context, obj interface{}) (context.Context, error) {
-				ctx = testInitializerNewContext(ctx, "foo")
+			InitCtxFunc: func(ctx context.Context, obj interface{}) (context.Context, error) {
+				ctx = testInitCtxFuncNewContext(ctx, "foo")
 				return ctx, nil
 			},
 			ExpectedOrder: []string{
@@ -43,13 +43,13 @@ func Test_Framework_Initializer_AddFunc(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
-		r := &testInitilizerResource{}
+		r := &testInitCtxFuncResource{}
 
 		var f *Framework
 		{
 			c := DefaultConfig()
 
-			c.Initializer = tc.Initializer
+			c.InitCtxFunc = tc.InitCtxFunc
 			c.Logger = microloggertest.New()
 			c.Resources = []Resource{
 				r,
@@ -70,23 +70,23 @@ func Test_Framework_Initializer_AddFunc(t *testing.T) {
 	}
 }
 
-func Test_Framework_Initializer_DeleteFunc(t *testing.T) {
+func Test_Framework_InitCtxFunc_DeleteFunc(t *testing.T) {
 	testCases := []struct {
 		CustomObject  interface{}
-		Initializer   func(ctx context.Context, obj interface{}) (context.Context, error)
+		InitCtxFunc   func(ctx context.Context, obj interface{}) (context.Context, error)
 		ExpectedOrder []string
 	}{
 		{
 			CustomObject: nil,
-			Initializer: func(ctx context.Context, obj interface{}) (context.Context, error) {
+			InitCtxFunc: func(ctx context.Context, obj interface{}) (context.Context, error) {
 				return ctx, nil
 			},
 			ExpectedOrder: nil,
 		},
 		{
 			CustomObject: nil,
-			Initializer: func(ctx context.Context, obj interface{}) (context.Context, error) {
-				ctx = testInitializerNewContext(ctx, "foo")
+			InitCtxFunc: func(ctx context.Context, obj interface{}) (context.Context, error) {
+				ctx = testInitCtxFuncNewContext(ctx, "foo")
 				return ctx, nil
 			},
 			ExpectedOrder: []string{
@@ -99,13 +99,13 @@ func Test_Framework_Initializer_DeleteFunc(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
-		r := &testInitilizerResource{}
+		r := &testInitCtxFuncResource{}
 
 		var f *Framework
 		{
 			c := DefaultConfig()
 
-			c.Initializer = tc.Initializer
+			c.InitCtxFunc = tc.InitCtxFunc
 			c.Logger = microloggertest.New()
 			c.Resources = []Resource{
 				r,
@@ -126,23 +126,23 @@ func Test_Framework_Initializer_DeleteFunc(t *testing.T) {
 	}
 }
 
-func Test_Framework_Initializer_UpdateFunc(t *testing.T) {
+func Test_Framework_InitCtxFunc_UpdateFunc(t *testing.T) {
 	testCases := []struct {
 		CustomObject  interface{}
-		Initializer   func(ctx context.Context, obj interface{}) (context.Context, error)
+		InitCtxFunc   func(ctx context.Context, obj interface{}) (context.Context, error)
 		ExpectedOrder []string
 	}{
 		{
 			CustomObject: nil,
-			Initializer: func(ctx context.Context, obj interface{}) (context.Context, error) {
+			InitCtxFunc: func(ctx context.Context, obj interface{}) (context.Context, error) {
 				return ctx, nil
 			},
 			ExpectedOrder: nil,
 		},
 		{
 			CustomObject: nil,
-			Initializer: func(ctx context.Context, obj interface{}) (context.Context, error) {
-				ctx = testInitializerNewContext(ctx, "foo")
+			InitCtxFunc: func(ctx context.Context, obj interface{}) (context.Context, error) {
+				ctx = testInitCtxFuncNewContext(ctx, "foo")
 				return ctx, nil
 			},
 			ExpectedOrder: []string{
@@ -161,13 +161,13 @@ func Test_Framework_Initializer_UpdateFunc(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
-		r := &testInitilizerResource{}
+		r := &testInitCtxFuncResource{}
 
 		var f *Framework
 		{
 			c := DefaultConfig()
 
-			c.Initializer = tc.Initializer
+			c.InitCtxFunc = tc.InitCtxFunc
 			c.Logger = microloggertest.New()
 			c.Resources = []Resource{
 				r,
@@ -188,12 +188,12 @@ func Test_Framework_Initializer_UpdateFunc(t *testing.T) {
 	}
 }
 
-type testInitilizerResource struct {
+type testInitCtxFuncResource struct {
 	Order []string
 }
 
-func (r *testInitilizerResource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
-	_, ok := testInitializerFromContext(ctx)
+func (r *testInitCtxFuncResource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
+	_, ok := testInitCtxFuncFromContext(ctx)
 	if ok {
 		m := "GetCurrentState"
 		r.Order = append(r.Order, m)
@@ -202,8 +202,8 @@ func (r *testInitilizerResource) GetCurrentState(ctx context.Context, obj interf
 	return nil, nil
 }
 
-func (r *testInitilizerResource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {
-	_, ok := testInitializerFromContext(ctx)
+func (r *testInitCtxFuncResource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {
+	_, ok := testInitCtxFuncFromContext(ctx)
 	if ok {
 		m := "GetDesiredState"
 		r.Order = append(r.Order, m)
@@ -212,8 +212,8 @@ func (r *testInitilizerResource) GetDesiredState(ctx context.Context, obj interf
 	return nil, nil
 }
 
-func (r *testInitilizerResource) GetCreateState(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
-	_, ok := testInitializerFromContext(ctx)
+func (r *testInitCtxFuncResource) GetCreateState(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	_, ok := testInitCtxFuncFromContext(ctx)
 	if ok {
 		m := "GetCreateState"
 		r.Order = append(r.Order, m)
@@ -222,8 +222,8 @@ func (r *testInitilizerResource) GetCreateState(ctx context.Context, obj, curren
 	return nil, nil
 }
 
-func (r *testInitilizerResource) GetDeleteState(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
-	_, ok := testInitializerFromContext(ctx)
+func (r *testInitCtxFuncResource) GetDeleteState(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	_, ok := testInitCtxFuncFromContext(ctx)
 	if ok {
 		m := "GetDeleteState"
 		r.Order = append(r.Order, m)
@@ -232,8 +232,8 @@ func (r *testInitilizerResource) GetDeleteState(ctx context.Context, obj, curren
 	return nil, nil
 }
 
-func (r *testInitilizerResource) GetUpdateState(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, interface{}, interface{}, error) {
-	_, ok := testInitializerFromContext(ctx)
+func (r *testInitCtxFuncResource) GetUpdateState(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, interface{}, interface{}, error) {
+	_, ok := testInitCtxFuncFromContext(ctx)
 	if ok {
 		m := "GetUpdateState"
 		r.Order = append(r.Order, m)
@@ -242,12 +242,12 @@ func (r *testInitilizerResource) GetUpdateState(ctx context.Context, obj, curren
 	return nil, nil, nil, nil
 }
 
-func (r *testInitilizerResource) Name() string {
-	return "testInitilizerResource"
+func (r *testInitCtxFuncResource) Name() string {
+	return "testInitCtxFuncResource"
 }
 
-func (r *testInitilizerResource) ProcessCreateState(ctx context.Context, obj, createState interface{}) error {
-	_, ok := testInitializerFromContext(ctx)
+func (r *testInitCtxFuncResource) ProcessCreateState(ctx context.Context, obj, createState interface{}) error {
+	_, ok := testInitCtxFuncFromContext(ctx)
 	if ok {
 		m := "ProcessCreateState"
 		r.Order = append(r.Order, m)
@@ -256,8 +256,8 @@ func (r *testInitilizerResource) ProcessCreateState(ctx context.Context, obj, cr
 	return nil
 }
 
-func (r *testInitilizerResource) ProcessDeleteState(ctx context.Context, obj, deleteState interface{}) error {
-	_, ok := testInitializerFromContext(ctx)
+func (r *testInitCtxFuncResource) ProcessDeleteState(ctx context.Context, obj, deleteState interface{}) error {
+	_, ok := testInitCtxFuncFromContext(ctx)
 	if ok {
 		m := "ProcessDeleteState"
 		r.Order = append(r.Order, m)
@@ -266,8 +266,8 @@ func (r *testInitilizerResource) ProcessDeleteState(ctx context.Context, obj, de
 	return nil
 }
 
-func (r *testInitilizerResource) ProcessUpdateState(ctx context.Context, obj, updateState interface{}) error {
-	_, ok := testInitializerFromContext(ctx)
+func (r *testInitCtxFuncResource) ProcessUpdateState(ctx context.Context, obj, updateState interface{}) error {
+	_, ok := testInitCtxFuncFromContext(ctx)
 	if ok {
 		m := "ProcessUpdateState"
 		r.Order = append(r.Order, m)
@@ -276,19 +276,19 @@ func (r *testInitilizerResource) ProcessUpdateState(ctx context.Context, obj, up
 	return nil
 }
 
-func (r *testInitilizerResource) Underlying() Resource {
+func (r *testInitCtxFuncResource) Underlying() Resource {
 	return r
 }
 
 type key string
 
-var testInitializerKey key = "testinitiaqlizer"
+var testInitCtxFuncKey key = "testinitiaqlizer"
 
-func testInitializerNewContext(ctx context.Context, v interface{}) context.Context {
-	return context.WithValue(ctx, testInitializerKey, v)
+func testInitCtxFuncNewContext(ctx context.Context, v interface{}) context.Context {
+	return context.WithValue(ctx, testInitCtxFuncKey, v)
 }
 
-func testInitializerFromContext(ctx context.Context) (interface{}, bool) {
-	v, ok := ctx.Value(testInitializerKey).(interface{})
+func testInitCtxFuncFromContext(ctx context.Context) (interface{}, bool) {
+	v, ok := ctx.Value(testInitCtxFuncKey).(interface{})
 	return v, ok
 }

--- a/framework/framework_initializer_test.go
+++ b/framework/framework_initializer_test.go
@@ -1,0 +1,294 @@
+package framework
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/giantswarm/micrologger/microloggertest"
+)
+
+func Test_Framework_Initializer_AddFunc(t *testing.T) {
+	testCases := []struct {
+		CustomObject  interface{}
+		Initializer   func(ctx context.Context, obj interface{}) (context.Context, error)
+		ExpectedOrder []string
+	}{
+		{
+			CustomObject: nil,
+			Initializer: func(ctx context.Context, obj interface{}) (context.Context, error) {
+				return ctx, nil
+			},
+			ExpectedOrder: nil,
+		},
+		{
+			CustomObject: nil,
+			Initializer: func(ctx context.Context, obj interface{}) (context.Context, error) {
+				ctx = testInitializerNewContext(ctx, "foo")
+				return ctx, nil
+			},
+			ExpectedOrder: []string{
+				"GetCurrentState",
+				"GetDesiredState",
+				"GetCreateState",
+				"ProcessCreateState",
+				"GetCurrentState",
+				"GetDesiredState",
+				"GetUpdateState",
+				"ProcessCreateState",
+				"ProcessDeleteState",
+				"ProcessUpdateState",
+			},
+		},
+	}
+
+	for i, tc := range testCases {
+		r := &testInitilizerResource{}
+
+		var f *Framework
+		{
+			c := DefaultConfig()
+
+			c.Initializer = tc.Initializer
+			c.Logger = microloggertest.New()
+			c.Resources = []Resource{
+				r,
+			}
+
+			var err error
+			f, err = New(c)
+			if err != nil {
+				t.Fatal("expected", nil, "got", err)
+			}
+		}
+
+		f.AddFunc(tc.CustomObject)
+
+		if !reflect.DeepEqual(tc.ExpectedOrder, r.Order) {
+			t.Fatal("test", i+1, "expected", tc.ExpectedOrder, "got", r.Order)
+		}
+	}
+}
+
+func Test_Framework_Initializer_DeleteFunc(t *testing.T) {
+	testCases := []struct {
+		CustomObject  interface{}
+		Initializer   func(ctx context.Context, obj interface{}) (context.Context, error)
+		ExpectedOrder []string
+	}{
+		{
+			CustomObject: nil,
+			Initializer: func(ctx context.Context, obj interface{}) (context.Context, error) {
+				return ctx, nil
+			},
+			ExpectedOrder: nil,
+		},
+		{
+			CustomObject: nil,
+			Initializer: func(ctx context.Context, obj interface{}) (context.Context, error) {
+				ctx = testInitializerNewContext(ctx, "foo")
+				return ctx, nil
+			},
+			ExpectedOrder: []string{
+				"GetCurrentState",
+				"GetDesiredState",
+				"GetDeleteState",
+				"ProcessDeleteState",
+			},
+		},
+	}
+
+	for i, tc := range testCases {
+		r := &testInitilizerResource{}
+
+		var f *Framework
+		{
+			c := DefaultConfig()
+
+			c.Initializer = tc.Initializer
+			c.Logger = microloggertest.New()
+			c.Resources = []Resource{
+				r,
+			}
+
+			var err error
+			f, err = New(c)
+			if err != nil {
+				t.Fatal("expected", nil, "got", err)
+			}
+		}
+
+		f.DeleteFunc(tc.CustomObject)
+
+		if !reflect.DeepEqual(tc.ExpectedOrder, r.Order) {
+			t.Fatal("test", i+1, "expected", tc.ExpectedOrder, "got", r.Order)
+		}
+	}
+}
+
+func Test_Framework_Initializer_UpdateFunc(t *testing.T) {
+	testCases := []struct {
+		CustomObject  interface{}
+		Initializer   func(ctx context.Context, obj interface{}) (context.Context, error)
+		ExpectedOrder []string
+	}{
+		{
+			CustomObject: nil,
+			Initializer: func(ctx context.Context, obj interface{}) (context.Context, error) {
+				return ctx, nil
+			},
+			ExpectedOrder: nil,
+		},
+		{
+			CustomObject: nil,
+			Initializer: func(ctx context.Context, obj interface{}) (context.Context, error) {
+				ctx = testInitializerNewContext(ctx, "foo")
+				return ctx, nil
+			},
+			ExpectedOrder: []string{
+				"GetCurrentState",
+				"GetDesiredState",
+				"GetCreateState",
+				"ProcessCreateState",
+				"GetCurrentState",
+				"GetDesiredState",
+				"GetUpdateState",
+				"ProcessCreateState",
+				"ProcessDeleteState",
+				"ProcessUpdateState",
+			},
+		},
+	}
+
+	for i, tc := range testCases {
+		r := &testInitilizerResource{}
+
+		var f *Framework
+		{
+			c := DefaultConfig()
+
+			c.Initializer = tc.Initializer
+			c.Logger = microloggertest.New()
+			c.Resources = []Resource{
+				r,
+			}
+
+			var err error
+			f, err = New(c)
+			if err != nil {
+				t.Fatal("expected", nil, "got", err)
+			}
+		}
+
+		f.UpdateFunc(nil, tc.CustomObject)
+
+		if !reflect.DeepEqual(tc.ExpectedOrder, r.Order) {
+			t.Fatal("test", i+1, "expected", tc.ExpectedOrder, "got", r.Order)
+		}
+	}
+}
+
+type testInitilizerResource struct {
+	Order []string
+}
+
+func (r *testInitilizerResource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
+	_, ok := testInitializerFromContext(ctx)
+	if ok {
+		m := "GetCurrentState"
+		r.Order = append(r.Order, m)
+	}
+
+	return nil, nil
+}
+
+func (r *testInitilizerResource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {
+	_, ok := testInitializerFromContext(ctx)
+	if ok {
+		m := "GetDesiredState"
+		r.Order = append(r.Order, m)
+	}
+
+	return nil, nil
+}
+
+func (r *testInitilizerResource) GetCreateState(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	_, ok := testInitializerFromContext(ctx)
+	if ok {
+		m := "GetCreateState"
+		r.Order = append(r.Order, m)
+	}
+
+	return nil, nil
+}
+
+func (r *testInitilizerResource) GetDeleteState(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	_, ok := testInitializerFromContext(ctx)
+	if ok {
+		m := "GetDeleteState"
+		r.Order = append(r.Order, m)
+	}
+
+	return nil, nil
+}
+
+func (r *testInitilizerResource) GetUpdateState(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, interface{}, interface{}, error) {
+	_, ok := testInitializerFromContext(ctx)
+	if ok {
+		m := "GetUpdateState"
+		r.Order = append(r.Order, m)
+	}
+
+	return nil, nil, nil, nil
+}
+
+func (r *testInitilizerResource) Name() string {
+	return "testInitilizerResource"
+}
+
+func (r *testInitilizerResource) ProcessCreateState(ctx context.Context, obj, createState interface{}) error {
+	_, ok := testInitializerFromContext(ctx)
+	if ok {
+		m := "ProcessCreateState"
+		r.Order = append(r.Order, m)
+	}
+
+	return nil
+}
+
+func (r *testInitilizerResource) ProcessDeleteState(ctx context.Context, obj, deleteState interface{}) error {
+	_, ok := testInitializerFromContext(ctx)
+	if ok {
+		m := "ProcessDeleteState"
+		r.Order = append(r.Order, m)
+	}
+
+	return nil
+}
+
+func (r *testInitilizerResource) ProcessUpdateState(ctx context.Context, obj, updateState interface{}) error {
+	_, ok := testInitializerFromContext(ctx)
+	if ok {
+		m := "ProcessUpdateState"
+		r.Order = append(r.Order, m)
+	}
+
+	return nil
+}
+
+func (r *testInitilizerResource) Underlying() Resource {
+	return r
+}
+
+type key string
+
+var testInitializerKey key = "testinitiaqlizer"
+
+func testInitializerNewContext(ctx context.Context, v interface{}) context.Context {
+	return context.WithValue(ctx, testInitializerKey, v)
+}
+
+func testInitializerFromContext(ctx context.Context) (interface{}, bool) {
+	v, ok := ctx.Value(testInitializerKey).(interface{})
+	return v, ok
+}


### PR DESCRIPTION
The initializer is necessary to get the inter resource communication right. See how it is used in https://github.com/giantswarm/kvm-operator/pull/197. 