### PR TITLE
added deletionallowedcontext package

### DIFF
--- a/context/deletionallowedcontext/deletion_allowed_context.go
+++ b/context/deletionallowedcontext/deletion_allowed_context.go
@@ -1,0 +1,62 @@
+// Package deletionallowedcontext stores and accesses the deletion allowed in
+// context.Context.
+package deletionallowedcontext
+
+import (
+	"context"
+)
+
+// key is an unexported type for keys defined in this package. This prevents
+// collisions with keys defined in other packages.
+type key string
+
+// deletionAllowedKey is the key for deletion allowed values in context.Context.
+// Clients use deletionallowedcontext.NewContext and
+// deletionallowedcontext.FromContext instead of using this key directly.
+var deletionAllowedKey key = "deletionallowed"
+
+// NewContext returns a new context.Context that carries value v.
+func NewContext(ctx context.Context, v chan struct{}) context.Context {
+	if v == nil {
+		return ctx
+	}
+
+	return context.WithValue(ctx, deletionAllowedKey, v)
+}
+
+// FromContext returns the deletion allowed channel, if any.
+func FromContext(ctx context.Context) (chan struct{}, bool) {
+	v, ok := ctx.Value(deletionAllowedKey).(chan struct{})
+	return v, ok
+}
+
+// IsDeletionAllowed checks whether the given context obtains information about
+// the deletion allowed channel as defined in this package, if any deletion
+// allowed channel is present.
+//
+// NOTE that the deletion allowed channel, if any found, is only used to be
+// closed to signal deletions are allowed. It is not guaranteed that the channel
+// is buffered or read from. Clients must not write to it. Otherwise the
+// deletion allowed channel will block eventually. It is safe to signal
+// deletions are allowed via SetDeletionAllowed.
+func IsDeletionAllowed(ctx context.Context) bool {
+	deletionAllowed, deletionAllowedExists := FromContext(ctx)
+	if deletionAllowedExists {
+		select {
+		case <-deletionAllowed:
+			return true
+		default:
+			// fall thorugh
+		}
+	}
+
+	return false
+}
+
+// SetDeletionAllowed is a safe way to signal deletions are allowed.
+func SetDeletionAllowed(ctx context.Context) {
+	deletionAllowed, deletionAllowedExists := FromContext(ctx)
+	if deletionAllowedExists && !IsDeletionAllowed(ctx) {
+		close(deletionAllowed)
+	}
+}

--- a/context/deletionallowedcontext/deletion_allowed_context_test.go
+++ b/context/deletionallowedcontext/deletion_allowed_context_test.go
@@ -1,0 +1,59 @@
+package deletionallowedcontext
+
+import (
+	"context"
+	"testing"
+)
+
+func Test_Framework_DeletionAllowedContext(t *testing.T) {
+	testCases := []struct {
+		Ctx                       context.Context
+		ExpectedIsDeletionAllowed bool
+	}{
+		{
+			Ctx: context.TODO(),
+			ExpectedIsDeletionAllowed: false,
+		},
+		{
+			Ctx: NewContext(context.Background(), nil),
+			ExpectedIsDeletionAllowed: false,
+		},
+		{
+			Ctx: NewContext(context.Background(), make(chan struct{})),
+			ExpectedIsDeletionAllowed: false,
+		},
+		{
+			Ctx: func() context.Context {
+				ctx := NewContext(context.Background(), nil)
+				SetDeletionAllowed(ctx)
+				return ctx
+			}(),
+			ExpectedIsDeletionAllowed: false,
+		},
+		{
+			Ctx: func() context.Context {
+				ctx := NewContext(context.Background(), make(chan struct{}))
+				SetDeletionAllowed(ctx)
+				return ctx
+			}(),
+			ExpectedIsDeletionAllowed: true,
+		},
+		{
+			Ctx: func() context.Context {
+				ctx := NewContext(context.Background(), make(chan struct{}))
+				SetDeletionAllowed(ctx)
+				SetDeletionAllowed(ctx)
+				SetDeletionAllowed(ctx)
+				return ctx
+			}(),
+			ExpectedIsDeletionAllowed: true,
+		},
+	}
+
+	for i, tc := range testCases {
+		isDeletionAllowed := IsDeletionAllowed(tc.Ctx)
+		if isDeletionAllowed != tc.ExpectedIsDeletionAllowed {
+			t.Fatal("test", i+1, "expected", tc.ExpectedIsDeletionAllowed, "got", isDeletionAllowed)
+		}
+	}
+}


### PR DESCRIPTION
This PR adds a new context package to have a mechanism to decide if the deletion of resources is allowed or not. We have this already for updates. I am currently working on the cert-operator where PKI backend resources are not allowed to be deleted when single certificates are deleted. Note that I created a new top level directory `context`. I would like to move the other context packages there as well to free the framework package. I would do this in a next step separately. 