### PR TITLE
fix import path

### DIFF
--- a/framework/framework.go
+++ b/framework/framework.go
@@ -12,7 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/cache"
 
-	"github.com/giantswarm/operatorkit/context/canceledcontext"
+	"github.com/giantswarm/operatorkit/framework/context/canceledcontext"
 )
 
 // Config represents the configuration used to create a new operator framework.

--- a/framework/framework_test.go
+++ b/framework/framework_test.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/giantswarm/operatorkit/context/canceledcontext"
+	"github.com/giantswarm/operatorkit/framework/context/canceledcontext"
 )
 
 // Test_Framework_ProcessCreate_ResourceOrder ensures the resource's methods are


### PR DESCRIPTION
I merged the former PR because CI was green. Architect is not building nor testing operatorkit right now. 