### PR TITLE
Removes unreachable code

### DIFF
--- a/framework/framework.go
+++ b/framework/framework.go
@@ -310,8 +310,6 @@ func (f *Framework) ProcessEvents(ctx context.Context, deleteChan chan watch.Eve
 				return nil
 			}
 		}
-
-		return nil
 	}
 
 	notifier := func(err error, d time.Duration) {

--- a/informer/informer.go
+++ b/informer/informer.go
@@ -310,8 +310,6 @@ func (i *Informer) fillCache(ctx context.Context, eventChan chan watch.Event) er
 			return nil
 		}
 	}
-
-	return nil
 }
 
 // isCachedFilled checks whether the informer cache is filled.
@@ -393,8 +391,6 @@ func (i *Informer) streamEvents(ctx context.Context, eventChan chan watch.Event)
 			}
 		}
 	}
-
-	return nil
 }
 
 // uncacheAndSend sends the received event to the provided delete channel and


### PR DESCRIPTION
See https://github.com/giantswarm/architect/pull/165

```
2017/10/16 10:42:37 running task: go-vet:	'docker run --rm -v /Users/joseph/go/src/github.com/giantswarm/operatorkit:/go/src/github.com/giantswarm/operatorkit -e GOPATH=/go -w /go/src/github.com/giantswarm/operatorkit quay.io/giantswarm/golang:1.9.1 go vet ./...'
framework/framework.go:314: unreachable code
exit status 1
informer/informer.go:314: unreachable code
informer/informer.go:397: unreachable code
exit status 1
2017/10/16 10:42:54 could not execute workflow: exit status 1
```