### PR TITLE
framework: compute patch in a single step

### DIFF
--- a/framework/framework.go
+++ b/framework/framework.go
@@ -272,9 +272,9 @@ func ProcessDelete(ctx context.Context, obj interface{}, resources []Resource) e
 		if canceledcontext.IsCanceled(ctx) {
 			return nil
 		}
-		createState, ok := patch.getCreate()
+		createState, ok := patch.getCreateChange()
 		if ok {
-			err := r.ApplyCreatePatch(ctx, obj, createState)
+			err := r.ApplyCreateChange(ctx, obj, createState)
 			if err != nil {
 				return microerror.Mask(err)
 			}
@@ -283,9 +283,9 @@ func ProcessDelete(ctx context.Context, obj interface{}, resources []Resource) e
 		if canceledcontext.IsCanceled(ctx) {
 			return nil
 		}
-		deleteState, ok := patch.getDelete()
+		deleteState, ok := patch.getDeleteChange()
 		if ok {
-			err := r.ApplyDeletePatch(ctx, obj, deleteState)
+			err := r.ApplyDeleteChange(ctx, obj, deleteState)
 			if err != nil {
 				return microerror.Mask(err)
 			}
@@ -294,9 +294,9 @@ func ProcessDelete(ctx context.Context, obj interface{}, resources []Resource) e
 		if canceledcontext.IsCanceled(ctx) {
 			return nil
 		}
-		updateState, ok := patch.getUpdate()
+		updateState, ok := patch.getUpdateChange()
 		if ok {
-			err := r.ApplyUpdatePatch(ctx, obj, updateState)
+			err := r.ApplyUpdateChange(ctx, obj, updateState)
 			if err != nil {
 				return microerror.Mask(err)
 			}
@@ -389,9 +389,9 @@ func ProcessUpdate(ctx context.Context, obj interface{}, resources []Resource) e
 		if canceledcontext.IsCanceled(ctx) {
 			return nil
 		}
-		createState, ok := patch.getCreate()
+		createState, ok := patch.getCreateChange()
 		if ok {
-			err := r.ApplyCreatePatch(ctx, obj, createState)
+			err := r.ApplyCreateChange(ctx, obj, createState)
 			if err != nil {
 				return microerror.Mask(err)
 			}
@@ -400,9 +400,9 @@ func ProcessUpdate(ctx context.Context, obj interface{}, resources []Resource) e
 		if canceledcontext.IsCanceled(ctx) {
 			return nil
 		}
-		deleteState, ok := patch.getDelete()
+		deleteState, ok := patch.getDeleteChange()
 		if ok {
-			err := r.ApplyDeletePatch(ctx, obj, deleteState)
+			err := r.ApplyDeleteChange(ctx, obj, deleteState)
 			if err != nil {
 				return microerror.Mask(err)
 			}
@@ -411,9 +411,9 @@ func ProcessUpdate(ctx context.Context, obj interface{}, resources []Resource) e
 		if canceledcontext.IsCanceled(ctx) {
 			return nil
 		}
-		updateState, ok := patch.getUpdate()
+		updateState, ok := patch.getUpdateChange()
 		if ok {
-			err := r.ApplyUpdatePatch(ctx, obj, updateState)
+			err := r.ApplyUpdateChange(ctx, obj, updateState)
 			if err != nil {
 				return microerror.Mask(err)
 			}

--- a/framework/framework.go
+++ b/framework/framework.go
@@ -255,7 +255,15 @@ func ProcessDelete(ctx context.Context, obj interface{}, resources []Resource) e
 		if canceledcontext.IsCanceled(ctx) {
 			return nil
 		}
-		patch, err := r.NewDeletePatch(ctx, obj, currentState)
+		desiredState, err := r.GetDesiredState(ctx, obj)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		if canceledcontext.IsCanceled(ctx) {
+			return nil
+		}
+		patch, err := r.NewDeletePatch(ctx, obj, currentState, desiredState)
 		if err != nil {
 			return microerror.Mask(err)
 		}
@@ -267,7 +275,7 @@ func ProcessDelete(ctx context.Context, obj interface{}, resources []Resource) e
 		}
 		createState, ok := patch.getCreate()
 		if ok {
-			err := r.Create(ctx, obj, createState)
+			err := r.ApplyCreatePatch(ctx, obj, createState)
 			if err != nil {
 				return microerror.Mask(err)
 			}
@@ -278,7 +286,7 @@ func ProcessDelete(ctx context.Context, obj interface{}, resources []Resource) e
 		}
 		deleteState, ok := patch.getDelete()
 		if ok {
-			err := r.Delete(ctx, obj, deleteState)
+			err := r.ApplyDeletePatch(ctx, obj, deleteState)
 			if err != nil {
 				return microerror.Mask(err)
 			}
@@ -289,7 +297,7 @@ func ProcessDelete(ctx context.Context, obj interface{}, resources []Resource) e
 		}
 		updateState, ok := patch.getUpdate()
 		if ok {
-			err := r.Update(ctx, obj, updateState)
+			err := r.ApplyUpdatePatch(ctx, obj, updateState)
 			if err != nil {
 				return microerror.Mask(err)
 			}
@@ -384,7 +392,7 @@ func ProcessUpdate(ctx context.Context, obj interface{}, resources []Resource) e
 		}
 		createState, ok := patch.getCreate()
 		if ok {
-			err := r.Create(ctx, obj, createState)
+			err := r.ApplyCreatePatch(ctx, obj, createState)
 			if err != nil {
 				return microerror.Mask(err)
 			}
@@ -395,7 +403,7 @@ func ProcessUpdate(ctx context.Context, obj interface{}, resources []Resource) e
 		}
 		deleteState, ok := patch.getDelete()
 		if ok {
-			err := r.Delete(ctx, obj, deleteState)
+			err := r.ApplyDeletePatch(ctx, obj, deleteState)
 			if err != nil {
 				return microerror.Mask(err)
 			}
@@ -406,7 +414,7 @@ func ProcessUpdate(ctx context.Context, obj interface{}, resources []Resource) e
 		}
 		updateState, ok := patch.getUpdate()
 		if ok {
-			err := r.Update(ctx, obj, updateState)
+			err := r.ApplyUpdatePatch(ctx, obj, updateState)
 			if err != nil {
 				return microerror.Mask(err)
 			}

--- a/framework/framework.go
+++ b/framework/framework.go
@@ -81,15 +81,13 @@ func New(config Config) (*Framework, error) {
 	return newFramework, nil
 }
 
-// AddFunc executes the framework's ProcessCreate and ProcessUpdate functions,
-// in this order. This guarantees resource creation is always done before
-// resource updates.
+// AddFunc executes the framework's ProcessCreate function.
 func (f *Framework) AddFunc(obj interface{}) {
-	// We lock the AddFunc/DeleteFunc to make sure only one AddFunc/DeleteFunc is
-	// executed at a time. AddFunc/DeleteFunc is not thread safe. This is
-	// important because the source of truth for an operator are the reconciled
-	// resources. In case we would run the operator logic in parallel, we would
-	// run into race conditions.
+	// AddFunc/DeleteFunc/UpdateFunc is synchornized to make sure only one
+	// of them is executed at a time. AddFunc/DeleteFunc/UpdateFunc is not
+	// thread safe. This is important because the source of truth for an
+	// operator are the reconciled resources. In case we would run the
+	// operator logic in parallel, we would run into race conditions.
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -114,25 +112,15 @@ func (f *Framework) AddFunc(obj interface{}) {
 	}
 
 	f.logger.Log("action", "end", "component", "operatorkit", "function", "ProcessCreate")
-
-	f.logger.Log("action", "start", "component", "operatorkit", "function", "ProcessUpdate")
-
-	err = ProcessUpdate(ctx, obj, f.resources)
-	if err != nil {
-		f.logger.Log("error", fmt.Sprintf("%#v", err), "event", "update")
-		return
-	}
-
-	f.logger.Log("action", "end", "component", "operatorkit", "function", "ProcessUpdate")
 }
 
 // DeleteFunc executes the framework's ProcessDelete function.
 func (f *Framework) DeleteFunc(obj interface{}) {
-	// We lock the AddFunc/DeleteFunc to make sure only one AddFunc/DeleteFunc is
-	// executed at a time. AddFunc/DeleteFunc is not thread safe. This is
-	// important because the source of truth for an operator are the reconciled
-	// resources. In case we would run the operator logic in parallel, we would
-	// run into race conditions.
+	// AddFunc/DeleteFunc/UpdateFunc is synchornized to make sure only one
+	// of them is executed at a time. AddFunc/DeleteFunc/UpdateFunc is not
+	// thread safe. This is important because the source of truth for an
+	// operator are the reconciled resources. In case we would run the
+	// operator logic in parallel, we would run into race conditions.
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -175,10 +163,40 @@ func (f *Framework) NewCacheResourceEventHandler() *cache.ResourceEventHandlerFu
 // UpdateFunc only redirects to AddFunc and only dispatches the new custom
 // object received.
 func (f *Framework) UpdateFunc(oldObj, newObj interface{}) {
-	f.AddFunc(newObj)
+	obj := newObj
+
+	// AddFunc/DeleteFunc/UpdateFunc is synchornized to make sure only one
+	// of them is executed at a time. AddFunc/DeleteFunc/UpdateFunc is not
+	// thread safe. This is important because the source of truth for an
+	// operator are the reconciled resources. In case we would run the
+	// operator logic in parallel, we would run into race conditions.
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	ctx := context.Background()
+	ctx = canceledcontext.NewContext(ctx, make(chan struct{}))
+
+	if f.initializer != nil {
+		var err error
+		ctx, err = f.initializer(ctx, obj)
+		if err != nil {
+			f.logger.Log("error", fmt.Sprintf("%#v", err), "event", "create")
+			return
+		}
+	}
+
+	f.logger.Log("action", "start", "component", "operatorkit", "function", "ProcessUpdate")
+
+	err := ProcessUpdate(ctx, obj, f.resources)
+	if err != nil {
+		f.logger.Log("error", fmt.Sprintf("%#v", err), "event", "update")
+		return
+	}
+
+	f.logger.Log("action", "end", "component", "operatorkit", "function", "ProcessUpdate")
 }
 
-// ProcessCreate is a drop-in for an informer's AddFunc. It receives the custom
+// ProcessAdd is a drop-in for an informer's AddFunc. It receives the custom
 // object observed during TPR watches and anything that implements Resource.
 // ProcessCreate takes care about all necessary reconciliation logic for create
 // events.
@@ -195,44 +213,10 @@ func (f *Framework) UpdateFunc(oldObj, newObj interface{}) {
 //     }
 //
 func ProcessCreate(ctx context.Context, obj interface{}, resources []Resource) error {
-	if len(resources) == 0 {
-		return microerror.Maskf(executionFailedError, "resources must not be empty")
+	err := ProcessUpdate(ctx, obj, resources)
+	if err != nil {
+		return microerror.Mask(err)
 	}
-
-	for _, r := range resources {
-		if canceledcontext.IsCanceled(ctx) {
-			return nil
-		}
-		currentState, err := r.GetCurrentState(ctx, obj)
-		if err != nil {
-			return microerror.Mask(err)
-		}
-
-		if canceledcontext.IsCanceled(ctx) {
-			return nil
-		}
-		desiredState, err := r.GetDesiredState(ctx, obj)
-		if err != nil {
-			return microerror.Mask(err)
-		}
-
-		if canceledcontext.IsCanceled(ctx) {
-			return nil
-		}
-		createState, err := r.GetCreateState(ctx, obj, currentState, desiredState)
-		if err != nil {
-			return microerror.Mask(err)
-		}
-
-		if canceledcontext.IsCanceled(ctx) {
-			return nil
-		}
-		err = r.ProcessCreateState(ctx, obj, createState)
-		if err != nil {
-			return microerror.Mask(err)
-		}
-	}
-
 	return nil
 }
 
@@ -258,6 +242,8 @@ func ProcessDelete(ctx context.Context, obj interface{}, resources []Resource) e
 	}
 
 	for _, r := range resources {
+		// Create the patch.
+
 		if canceledcontext.IsCanceled(ctx) {
 			return nil
 		}
@@ -269,26 +255,46 @@ func ProcessDelete(ctx context.Context, obj interface{}, resources []Resource) e
 		if canceledcontext.IsCanceled(ctx) {
 			return nil
 		}
-		desiredState, err := r.GetDesiredState(ctx, obj)
+		patch, err := r.NewDeletePatch(ctx, obj, currentState)
 		if err != nil {
 			return microerror.Mask(err)
+		}
+
+		// Apply the patch.
+
+		if canceledcontext.IsCanceled(ctx) {
+			return nil
+		}
+		createState, ok := patch.getCreate()
+		if ok {
+			err := r.Create(ctx, obj, createState)
+			if err != nil {
+				return microerror.Mask(err)
+			}
 		}
 
 		if canceledcontext.IsCanceled(ctx) {
 			return nil
 		}
-		deleteState, err := r.GetDeleteState(ctx, obj, currentState, desiredState)
-		if err != nil {
-			return microerror.Mask(err)
+		deleteState, ok := patch.getDelete()
+		if ok {
+			err := r.Delete(ctx, obj, deleteState)
+			if err != nil {
+				return microerror.Mask(err)
+			}
 		}
 
 		if canceledcontext.IsCanceled(ctx) {
 			return nil
 		}
-		err = r.ProcessDeleteState(ctx, obj, deleteState)
-		if err != nil {
-			return microerror.Mask(err)
+		updateState, ok := patch.getUpdate()
+		if ok {
+			err := r.Update(ctx, obj, updateState)
+			if err != nil {
+				return microerror.Mask(err)
+			}
 		}
+
 	}
 
 	return nil
@@ -345,6 +351,8 @@ func ProcessUpdate(ctx context.Context, obj interface{}, resources []Resource) e
 	}
 
 	for _, r := range resources {
+		// Create the patch.
+
 		if canceledcontext.IsCanceled(ctx) {
 			return nil
 		}
@@ -364,33 +372,44 @@ func ProcessUpdate(ctx context.Context, obj interface{}, resources []Resource) e
 		if canceledcontext.IsCanceled(ctx) {
 			return nil
 		}
-		createState, deleteState, updateState, err := r.GetUpdateState(ctx, obj, currentState, desiredState)
+		patch, err := r.NewUpdatePatch(ctx, obj, currentState, desiredState)
 		if err != nil {
 			return microerror.Mask(err)
+		}
+
+		// Apply the patch.
+
+		if canceledcontext.IsCanceled(ctx) {
+			return nil
+		}
+		createState, ok := patch.getCreate()
+		if ok {
+			err := r.Create(ctx, obj, createState)
+			if err != nil {
+				return microerror.Mask(err)
+			}
 		}
 
 		if canceledcontext.IsCanceled(ctx) {
 			return nil
 		}
-		err = r.ProcessCreateState(ctx, obj, createState)
-		if err != nil {
-			return microerror.Mask(err)
+		deleteState, ok := patch.getDelete()
+		if ok {
+			err := r.Delete(ctx, obj, deleteState)
+			if err != nil {
+				return microerror.Mask(err)
+			}
 		}
 
 		if canceledcontext.IsCanceled(ctx) {
 			return nil
 		}
-		err = r.ProcessDeleteState(ctx, obj, deleteState)
-		if err != nil {
-			return microerror.Mask(err)
-		}
-
-		if canceledcontext.IsCanceled(ctx) {
-			return nil
-		}
-		err = r.ProcessUpdateState(ctx, obj, updateState)
-		if err != nil {
-			return microerror.Mask(err)
+		updateState, ok := patch.getUpdate()
+		if ok {
+			err := r.Update(ctx, obj, updateState)
+			if err != nil {
+				return microerror.Mask(err)
+			}
 		}
 	}
 

--- a/framework/framework.go
+++ b/framework/framework.go
@@ -83,7 +83,7 @@ func New(config Config) (*Framework, error) {
 
 // AddFunc executes the framework's ProcessCreate function.
 func (f *Framework) AddFunc(obj interface{}) {
-	// AddFunc/DeleteFunc/UpdateFunc is synchornized to make sure only one
+	// AddFunc/DeleteFunc/UpdateFunc is synchronized to make sure only one
 	// of them is executed at a time. AddFunc/DeleteFunc/UpdateFunc is not
 	// thread safe. This is important because the source of truth for an
 	// operator are the reconciled resources. In case we would run the
@@ -116,7 +116,7 @@ func (f *Framework) AddFunc(obj interface{}) {
 
 // DeleteFunc executes the framework's ProcessDelete function.
 func (f *Framework) DeleteFunc(obj interface{}) {
-	// AddFunc/DeleteFunc/UpdateFunc is synchornized to make sure only one
+	// AddFunc/DeleteFunc/UpdateFunc is synchronized to make sure only one
 	// of them is executed at a time. AddFunc/DeleteFunc/UpdateFunc is not
 	// thread safe. This is important because the source of truth for an
 	// operator are the reconciled resources. In case we would run the
@@ -160,12 +160,11 @@ func (f *Framework) NewCacheResourceEventHandler() *cache.ResourceEventHandlerFu
 	return newHandler
 }
 
-// UpdateFunc only redirects to AddFunc and only dispatches the new custom
-// object received.
+// UpdateFunc executes the framework's ProcessUpdate function.
 func (f *Framework) UpdateFunc(oldObj, newObj interface{}) {
 	obj := newObj
 
-	// AddFunc/DeleteFunc/UpdateFunc is synchornized to make sure only one
+	// AddFunc/DeleteFunc/UpdateFunc is synchronized to make sure only one
 	// of them is executed at a time. AddFunc/DeleteFunc/UpdateFunc is not
 	// thread safe. This is important because the source of truth for an
 	// operator are the reconciled resources. In case we would run the
@@ -196,7 +195,7 @@ func (f *Framework) UpdateFunc(oldObj, newObj interface{}) {
 	f.logger.Log("action", "end", "component", "operatorkit", "function", "ProcessUpdate")
 }
 
-// ProcessAdd is a drop-in for an informer's AddFunc. It receives the custom
+// ProcessCreate is a drop-in for an informer's AddFunc. It receives the custom
 // object observed during TPR watches and anything that implements Resource.
 // ProcessCreate takes care about all necessary reconciliation logic for create
 // events.

--- a/framework/framework.go
+++ b/framework/framework.go
@@ -272,9 +272,9 @@ func ProcessDelete(ctx context.Context, obj interface{}, resources []Resource) e
 		if canceledcontext.IsCanceled(ctx) {
 			return nil
 		}
-		createState, ok := patch.getCreateChange()
+		createChange, ok := patch.getCreateChange()
 		if ok {
-			err := r.ApplyCreateChange(ctx, obj, createState)
+			err := r.ApplyCreateChange(ctx, obj, createChange)
 			if err != nil {
 				return microerror.Mask(err)
 			}
@@ -283,9 +283,9 @@ func ProcessDelete(ctx context.Context, obj interface{}, resources []Resource) e
 		if canceledcontext.IsCanceled(ctx) {
 			return nil
 		}
-		deleteState, ok := patch.getDeleteChange()
+		deleteChange, ok := patch.getDeleteChange()
 		if ok {
-			err := r.ApplyDeleteChange(ctx, obj, deleteState)
+			err := r.ApplyDeleteChange(ctx, obj, deleteChange)
 			if err != nil {
 				return microerror.Mask(err)
 			}
@@ -294,9 +294,9 @@ func ProcessDelete(ctx context.Context, obj interface{}, resources []Resource) e
 		if canceledcontext.IsCanceled(ctx) {
 			return nil
 		}
-		updateState, ok := patch.getUpdateChange()
+		updateChange, ok := patch.getUpdateChange()
 		if ok {
-			err := r.ApplyUpdateChange(ctx, obj, updateState)
+			err := r.ApplyUpdateChange(ctx, obj, updateChange)
 			if err != nil {
 				return microerror.Mask(err)
 			}

--- a/framework/framework_initializer_test.go
+++ b/framework/framework_initializer_test.go
@@ -31,14 +31,10 @@ func Test_Framework_InitCtxFunc_AddFunc(t *testing.T) {
 			ExpectedOrder: []string{
 				"GetCurrentState",
 				"GetDesiredState",
-				"GetCreateState",
-				"ProcessCreateState",
-				"GetCurrentState",
-				"GetDesiredState",
-				"GetUpdateState",
-				"ProcessCreateState",
-				"ProcessDeleteState",
-				"ProcessUpdateState",
+				"NewUpdatePatch",
+				"Create",
+				"Delete",
+				"Update",
 			},
 		},
 	}
@@ -93,9 +89,10 @@ func Test_Framework_InitCtxFunc_DeleteFunc(t *testing.T) {
 			},
 			ExpectedOrder: []string{
 				"GetCurrentState",
-				"GetDesiredState",
-				"GetDeleteState",
-				"ProcessDeleteState",
+				"NewDeletePatch",
+				"Create",
+				"Delete",
+				"Update",
 			},
 		},
 	}
@@ -151,14 +148,10 @@ func Test_Framework_InitCtxFunc_UpdateFunc(t *testing.T) {
 			ExpectedOrder: []string{
 				"GetCurrentState",
 				"GetDesiredState",
-				"GetCreateState",
-				"ProcessCreateState",
-				"GetCurrentState",
-				"GetDesiredState",
-				"GetUpdateState",
-				"ProcessCreateState",
-				"ProcessDeleteState",
-				"ProcessUpdateState",
+				"NewUpdatePatch",
+				"Create",
+				"Delete",
+				"Update",
 			},
 		},
 	}
@@ -216,64 +209,64 @@ func (r *testInitCtxFuncResource) GetDesiredState(ctx context.Context, obj inter
 	return nil, nil
 }
 
-func (r *testInitCtxFuncResource) GetCreateState(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+func (r *testInitCtxFuncResource) NewUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*Patch, error) {
 	_, ok := testInitCtxFuncFromContext(ctx)
 	if ok {
-		m := "GetCreateState"
+		m := "NewUpdatePatch"
 		r.Order = append(r.Order, m)
 	}
 
-	return nil, nil
+	// TODO test not invoking when patch part is not set.
+	p := NewPatch()
+	p.SetCreate("test create state")
+	p.SetUpdate("test update state")
+	p.SetDelete("test delete state")
+	return p, nil
 }
 
-func (r *testInitCtxFuncResource) GetDeleteState(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+func (r *testInitCtxFuncResource) NewDeletePatch(ctx context.Context, obj, currentState interface{}) (*Patch, error) {
 	_, ok := testInitCtxFuncFromContext(ctx)
 	if ok {
-		m := "GetDeleteState"
+		m := "NewDeletePatch"
 		r.Order = append(r.Order, m)
 	}
 
-	return nil, nil
-}
-
-func (r *testInitCtxFuncResource) GetUpdateState(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, interface{}, interface{}, error) {
-	_, ok := testInitCtxFuncFromContext(ctx)
-	if ok {
-		m := "GetUpdateState"
-		r.Order = append(r.Order, m)
-	}
-
-	return nil, nil, nil, nil
+	// TODO test not invoking when patch part is not set.
+	p := NewPatch()
+	p.SetCreate("test create state")
+	p.SetUpdate("test update state")
+	p.SetDelete("test delete state")
+	return p, nil
 }
 
 func (r *testInitCtxFuncResource) Name() string {
 	return "testInitCtxFuncResource"
 }
 
-func (r *testInitCtxFuncResource) ProcessCreateState(ctx context.Context, obj, createState interface{}) error {
+func (r *testInitCtxFuncResource) Create(ctx context.Context, obj, createState interface{}) error {
 	_, ok := testInitCtxFuncFromContext(ctx)
 	if ok {
-		m := "ProcessCreateState"
+		m := "Create"
 		r.Order = append(r.Order, m)
 	}
 
 	return nil
 }
 
-func (r *testInitCtxFuncResource) ProcessDeleteState(ctx context.Context, obj, deleteState interface{}) error {
+func (r *testInitCtxFuncResource) Delete(ctx context.Context, obj, deleteState interface{}) error {
 	_, ok := testInitCtxFuncFromContext(ctx)
 	if ok {
-		m := "ProcessDeleteState"
+		m := "Delete"
 		r.Order = append(r.Order, m)
 	}
 
 	return nil
 }
 
-func (r *testInitCtxFuncResource) ProcessUpdateState(ctx context.Context, obj, updateState interface{}) error {
+func (r *testInitCtxFuncResource) Update(ctx context.Context, obj, updateState interface{}) error {
 	_, ok := testInitCtxFuncFromContext(ctx)
 	if ok {
-		m := "ProcessUpdateState"
+		m := "Update"
 		r.Order = append(r.Order, m)
 	}
 

--- a/framework/framework_initializer_test.go
+++ b/framework/framework_initializer_test.go
@@ -89,6 +89,7 @@ func Test_Framework_InitCtxFunc_DeleteFunc(t *testing.T) {
 			},
 			ExpectedOrder: []string{
 				"GetCurrentState",
+				"GetDesiredState",
 				"NewDeletePatch",
 				"Create",
 				"Delete",
@@ -224,7 +225,7 @@ func (r *testInitCtxFuncResource) NewUpdatePatch(ctx context.Context, obj, curre
 	return p, nil
 }
 
-func (r *testInitCtxFuncResource) NewDeletePatch(ctx context.Context, obj, currentState interface{}) (*Patch, error) {
+func (r *testInitCtxFuncResource) NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*Patch, error) {
 	_, ok := testInitCtxFuncFromContext(ctx)
 	if ok {
 		m := "NewDeletePatch"
@@ -243,7 +244,7 @@ func (r *testInitCtxFuncResource) Name() string {
 	return "testInitCtxFuncResource"
 }
 
-func (r *testInitCtxFuncResource) Create(ctx context.Context, obj, createState interface{}) error {
+func (r *testInitCtxFuncResource) ApplyCreatePatch(ctx context.Context, obj, createState interface{}) error {
 	_, ok := testInitCtxFuncFromContext(ctx)
 	if ok {
 		m := "Create"
@@ -253,7 +254,7 @@ func (r *testInitCtxFuncResource) Create(ctx context.Context, obj, createState i
 	return nil
 }
 
-func (r *testInitCtxFuncResource) Delete(ctx context.Context, obj, deleteState interface{}) error {
+func (r *testInitCtxFuncResource) ApplyDeletePatch(ctx context.Context, obj, deleteState interface{}) error {
 	_, ok := testInitCtxFuncFromContext(ctx)
 	if ok {
 		m := "Delete"
@@ -263,7 +264,7 @@ func (r *testInitCtxFuncResource) Delete(ctx context.Context, obj, deleteState i
 	return nil
 }
 
-func (r *testInitCtxFuncResource) Update(ctx context.Context, obj, updateState interface{}) error {
+func (r *testInitCtxFuncResource) ApplyUpdatePatch(ctx context.Context, obj, updateState interface{}) error {
 	_, ok := testInitCtxFuncFromContext(ctx)
 	if ok {
 		m := "Update"

--- a/framework/framework_initializer_test.go
+++ b/framework/framework_initializer_test.go
@@ -217,7 +217,6 @@ func (r *testInitCtxFuncResource) NewUpdatePatch(ctx context.Context, obj, curre
 		r.Order = append(r.Order, m)
 	}
 
-	// TODO test not invoking when patch part is not set.
 	p := NewPatch()
 	p.SetCreate("test create state")
 	p.SetUpdate("test update state")
@@ -232,7 +231,6 @@ func (r *testInitCtxFuncResource) NewDeletePatch(ctx context.Context, obj, curre
 		r.Order = append(r.Order, m)
 	}
 
-	// TODO test not invoking when patch part is not set.
 	p := NewPatch()
 	p.SetCreate("test create state")
 	p.SetUpdate("test update state")

--- a/framework/framework_initializer_test.go
+++ b/framework/framework_initializer_test.go
@@ -218,9 +218,9 @@ func (r *testInitCtxFuncResource) NewUpdatePatch(ctx context.Context, obj, curre
 	}
 
 	p := NewPatch()
-	p.SetCreate("test create state")
-	p.SetUpdate("test update state")
-	p.SetDelete("test delete state")
+	p.SetCreateChange("test create state")
+	p.SetUpdateChange("test update state")
+	p.SetDeleteChange("test delete state")
 	return p, nil
 }
 
@@ -232,9 +232,9 @@ func (r *testInitCtxFuncResource) NewDeletePatch(ctx context.Context, obj, curre
 	}
 
 	p := NewPatch()
-	p.SetCreate("test create state")
-	p.SetUpdate("test update state")
-	p.SetDelete("test delete state")
+	p.SetCreateChange("test create state")
+	p.SetUpdateChange("test update state")
+	p.SetDeleteChange("test delete state")
 	return p, nil
 }
 
@@ -242,7 +242,7 @@ func (r *testInitCtxFuncResource) Name() string {
 	return "testInitCtxFuncResource"
 }
 
-func (r *testInitCtxFuncResource) ApplyCreatePatch(ctx context.Context, obj, createState interface{}) error {
+func (r *testInitCtxFuncResource) ApplyCreateChange(ctx context.Context, obj, createState interface{}) error {
 	_, ok := testInitCtxFuncFromContext(ctx)
 	if ok {
 		m := "Create"
@@ -252,7 +252,7 @@ func (r *testInitCtxFuncResource) ApplyCreatePatch(ctx context.Context, obj, cre
 	return nil
 }
 
-func (r *testInitCtxFuncResource) ApplyDeletePatch(ctx context.Context, obj, deleteState interface{}) error {
+func (r *testInitCtxFuncResource) ApplyDeleteChange(ctx context.Context, obj, deleteState interface{}) error {
 	_, ok := testInitCtxFuncFromContext(ctx)
 	if ok {
 		m := "Delete"
@@ -262,7 +262,7 @@ func (r *testInitCtxFuncResource) ApplyDeletePatch(ctx context.Context, obj, del
 	return nil
 }
 
-func (r *testInitCtxFuncResource) ApplyUpdatePatch(ctx context.Context, obj, updateState interface{}) error {
+func (r *testInitCtxFuncResource) ApplyUpdateChange(ctx context.Context, obj, updateState interface{}) error {
 	_, ok := testInitCtxFuncFromContext(ctx)
 	if ok {
 		m := "Update"

--- a/framework/framework_test.go
+++ b/framework/framework_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/giantswarm/operatorkit/framework/context/canceledcontext"
 )
 
-// Test_Framework_ProcessCreate_ResourceOrder ensures the resource's methods are
+// Test_Framework_ResourceCallOrder ensures the resource's methods are
 // executed as expected when creating resources.
-func Test_Framework_ProcessCreate_ResourceOrder(t *testing.T) {
+func Test_Framework_ResourceCallOrder(t *testing.T) {
 	testCases := []struct {
 		ProcessMethod  func(ctx context.Context, obj interface{}, rs []Resource) error
 		Ctx            context.Context
@@ -41,9 +41,9 @@ func Test_Framework_ProcessCreate_ResourceOrder(t *testing.T) {
 					"GetCurrentState",
 					"GetDesiredState",
 					"NewUpdatePatch",
-					"Create",
-					"Delete",
-					"Update",
+					"ApplyCreatePatch",
+					"ApplyDeletePatch",
+					"ApplyUpdatePatch",
 				},
 			},
 			ErrorMatcher: nil,
@@ -63,17 +63,17 @@ func Test_Framework_ProcessCreate_ResourceOrder(t *testing.T) {
 					"GetCurrentState",
 					"GetDesiredState",
 					"NewUpdatePatch",
-					"Create",
-					"Delete",
-					"Update",
+					"ApplyCreatePatch",
+					"ApplyDeletePatch",
+					"ApplyUpdatePatch",
 				},
 				{
 					"GetCurrentState",
 					"GetDesiredState",
 					"NewUpdatePatch",
-					"Create",
-					"Delete",
-					"Update",
+					"ApplyCreatePatch",
+					"ApplyDeletePatch",
+					"ApplyUpdatePatch",
 				},
 			},
 			ErrorMatcher: nil,
@@ -113,9 +113,9 @@ func Test_Framework_ProcessCreate_ResourceOrder(t *testing.T) {
 					"GetCurrentState",
 					"GetDesiredState",
 					"NewUpdatePatch",
-					"Create",
-					"Delete",
-					"Update",
+					"ApplyCreatePatch",
+					"ApplyDeletePatch",
+					"ApplyUpdatePatch",
 				},
 			},
 			ErrorMatcher: nil,
@@ -161,9 +161,9 @@ func Test_Framework_ProcessCreate_ResourceOrder(t *testing.T) {
 					"GetCurrentState",
 					"GetDesiredState",
 					"NewUpdatePatch",
-					"Create",
-					"Delete",
-					"Update",
+					"ApplyCreatePatch",
+					"ApplyDeletePatch",
+					"ApplyUpdatePatch",
 				},
 				{
 					"GetCurrentState",
@@ -197,9 +197,9 @@ func Test_Framework_ProcessCreate_ResourceOrder(t *testing.T) {
 					"GetCurrentState",
 					"GetDesiredState",
 					"NewDeletePatch",
-					"Create",
-					"Delete",
-					"Update",
+					"ApplyCreatePatch",
+					"ApplyDeletePatch",
+					"ApplyUpdatePatch",
 				},
 			},
 			ErrorMatcher: nil,
@@ -219,17 +219,17 @@ func Test_Framework_ProcessCreate_ResourceOrder(t *testing.T) {
 					"GetCurrentState",
 					"GetDesiredState",
 					"NewDeletePatch",
-					"Create",
-					"Delete",
-					"Update",
+					"ApplyCreatePatch",
+					"ApplyDeletePatch",
+					"ApplyUpdatePatch",
 				},
 				{
 					"GetCurrentState",
 					"GetDesiredState",
 					"NewDeletePatch",
-					"Create",
-					"Delete",
-					"Update",
+					"ApplyCreatePatch",
+					"ApplyDeletePatch",
+					"ApplyUpdatePatch",
 				},
 			},
 			ErrorMatcher: nil,
@@ -269,9 +269,9 @@ func Test_Framework_ProcessCreate_ResourceOrder(t *testing.T) {
 					"GetCurrentState",
 					"GetDesiredState",
 					"NewDeletePatch",
-					"Create",
-					"Delete",
-					"Update",
+					"ApplyCreatePatch",
+					"ApplyDeletePatch",
+					"ApplyUpdatePatch",
 				},
 			},
 			ErrorMatcher: nil,
@@ -317,9 +317,9 @@ func Test_Framework_ProcessCreate_ResourceOrder(t *testing.T) {
 					"GetCurrentState",
 					"GetDesiredState",
 					"NewDeletePatch",
-					"Create",
-					"Delete",
-					"Update",
+					"ApplyCreatePatch",
+					"ApplyDeletePatch",
+					"ApplyUpdatePatch",
 				},
 				{
 					"GetCurrentState",
@@ -353,9 +353,9 @@ func Test_Framework_ProcessCreate_ResourceOrder(t *testing.T) {
 					"GetCurrentState",
 					"GetDesiredState",
 					"NewUpdatePatch",
-					"Create",
-					"Delete",
-					"Update",
+					"ApplyCreatePatch",
+					"ApplyDeletePatch",
+					"ApplyUpdatePatch",
 				},
 			},
 			ErrorMatcher: nil,
@@ -375,17 +375,17 @@ func Test_Framework_ProcessCreate_ResourceOrder(t *testing.T) {
 					"GetCurrentState",
 					"GetDesiredState",
 					"NewUpdatePatch",
-					"Create",
-					"Delete",
-					"Update",
+					"ApplyCreatePatch",
+					"ApplyDeletePatch",
+					"ApplyUpdatePatch",
 				},
 				{
 					"GetCurrentState",
 					"GetDesiredState",
 					"NewUpdatePatch",
-					"Create",
-					"Delete",
-					"Update",
+					"ApplyCreatePatch",
+					"ApplyDeletePatch",
+					"ApplyUpdatePatch",
 				},
 			},
 			ErrorMatcher: nil,
@@ -425,9 +425,9 @@ func Test_Framework_ProcessCreate_ResourceOrder(t *testing.T) {
 					"GetCurrentState",
 					"GetDesiredState",
 					"NewUpdatePatch",
-					"Create",
-					"Delete",
-					"Update",
+					"ApplyCreatePatch",
+					"ApplyDeletePatch",
+					"ApplyUpdatePatch",
 				},
 			},
 			ErrorMatcher: nil,
@@ -473,14 +473,215 @@ func Test_Framework_ProcessCreate_ResourceOrder(t *testing.T) {
 					"GetCurrentState",
 					"GetDesiredState",
 					"NewUpdatePatch",
-					"Create",
-					"Delete",
-					"Update",
+					"ApplyCreatePatch",
+					"ApplyDeletePatch",
+					"ApplyUpdatePatch",
 				},
 				{
 					"GetCurrentState",
 					"GetDesiredState",
 					"NewUpdatePatch",
+				},
+			},
+			ErrorMatcher: nil,
+		},
+
+		// Test 22 ensures ProcessCreate calls Resource.Apply*Patch
+		// only when Patch has corresponding part set.
+		{
+			ProcessMethod: ProcessCreate,
+			Ctx:           canceledcontext.NewContext(context.Background(), make(chan struct{})),
+			Resources: []Resource{
+				&testResource{
+					SetupPatchFunc: func(p *Patch) {
+					},
+				},
+				&testResource{
+					SetupPatchFunc: func(p *Patch) {
+						p.SetCreate("test create data")
+					},
+				},
+				&testResource{
+					SetupPatchFunc: func(p *Patch) {
+						p.SetDelete("test delete data")
+					},
+				},
+				&testResource{
+					SetupPatchFunc: func(p *Patch) {
+						p.SetUpdate("test update data")
+					},
+				},
+				&testResource{
+					SetupPatchFunc: func(p *Patch) {
+						p.SetCreate("test create data")
+						p.SetDelete("test delete data")
+					},
+				},
+			},
+			ExpectedOrders: [][]string{
+				{
+					"GetCurrentState",
+					"GetDesiredState",
+					"NewUpdatePatch",
+				},
+				{
+					"GetCurrentState",
+					"GetDesiredState",
+					"NewUpdatePatch",
+					"ApplyCreatePatch",
+				},
+				{
+					"GetCurrentState",
+					"GetDesiredState",
+					"NewUpdatePatch",
+					"ApplyDeletePatch",
+				},
+				{
+					"GetCurrentState",
+					"GetDesiredState",
+					"NewUpdatePatch",
+					"ApplyUpdatePatch",
+				},
+				{
+					"GetCurrentState",
+					"GetDesiredState",
+					"NewUpdatePatch",
+					"ApplyCreatePatch",
+					"ApplyDeletePatch",
+				},
+			},
+			ErrorMatcher: nil,
+		},
+
+		// Test 23 ensures ProcessDelete calls Resource.Apply*Patch
+		// only when Patch has corresponding part set.
+		{
+			ProcessMethod: ProcessDelete,
+			Ctx:           canceledcontext.NewContext(context.Background(), make(chan struct{})),
+			Resources: []Resource{
+				&testResource{
+					SetupPatchFunc: func(p *Patch) {
+					},
+				},
+				&testResource{
+					SetupPatchFunc: func(p *Patch) {
+						p.SetCreate("test create data")
+					},
+				},
+				&testResource{
+					SetupPatchFunc: func(p *Patch) {
+						p.SetDelete("test delete data")
+					},
+				},
+				&testResource{
+					SetupPatchFunc: func(p *Patch) {
+						p.SetUpdate("test update data")
+					},
+				},
+				&testResource{
+					SetupPatchFunc: func(p *Patch) {
+						p.SetCreate("test create data")
+						p.SetDelete("test delete data")
+					},
+				},
+			},
+			ExpectedOrders: [][]string{
+				{
+					"GetCurrentState",
+					"GetDesiredState",
+					"NewDeletePatch",
+				},
+				{
+					"GetCurrentState",
+					"GetDesiredState",
+					"NewDeletePatch",
+					"ApplyCreatePatch",
+				},
+				{
+					"GetCurrentState",
+					"GetDesiredState",
+					"NewDeletePatch",
+					"ApplyDeletePatch",
+				},
+				{
+					"GetCurrentState",
+					"GetDesiredState",
+					"NewDeletePatch",
+					"ApplyUpdatePatch",
+				},
+				{
+					"GetCurrentState",
+					"GetDesiredState",
+					"NewDeletePatch",
+					"ApplyCreatePatch",
+					"ApplyDeletePatch",
+				},
+			},
+			ErrorMatcher: nil,
+		},
+
+		// Test 24 ensures ProcessUpdate calls Resource.Apply*Patch
+		// only when Patch has corresponding part set.
+		{
+			ProcessMethod: ProcessUpdate,
+			Ctx:           canceledcontext.NewContext(context.Background(), make(chan struct{})),
+			Resources: []Resource{
+				&testResource{
+					SetupPatchFunc: func(p *Patch) {
+					},
+				},
+				&testResource{
+					SetupPatchFunc: func(p *Patch) {
+						p.SetCreate("test create data")
+					},
+				},
+				&testResource{
+					SetupPatchFunc: func(p *Patch) {
+						p.SetDelete("test delete data")
+					},
+				},
+				&testResource{
+					SetupPatchFunc: func(p *Patch) {
+						p.SetUpdate("test update data")
+					},
+				},
+				&testResource{
+					SetupPatchFunc: func(p *Patch) {
+						p.SetCreate("test create data")
+						p.SetDelete("test delete data")
+					},
+				},
+			},
+			ExpectedOrders: [][]string{
+				{
+					"GetCurrentState",
+					"GetDesiredState",
+					"NewUpdatePatch",
+				},
+				{
+					"GetCurrentState",
+					"GetDesiredState",
+					"NewUpdatePatch",
+					"ApplyCreatePatch",
+				},
+				{
+					"GetCurrentState",
+					"GetDesiredState",
+					"NewUpdatePatch",
+					"ApplyDeletePatch",
+				},
+				{
+					"GetCurrentState",
+					"GetDesiredState",
+					"NewUpdatePatch",
+					"ApplyUpdatePatch",
+				},
+				{
+					"GetCurrentState",
+					"GetDesiredState",
+					"NewUpdatePatch",
+					"ApplyCreatePatch",
+					"ApplyDeletePatch",
 				},
 			},
 			ErrorMatcher: nil,
@@ -510,11 +711,12 @@ func Test_Framework_ProcessCreate_ResourceOrder(t *testing.T) {
 }
 
 type testResource struct {
-	CancelingStep string
-	Error         error
-	ErrorCount    int
-	ErrorMethod   string
-	Order         []string
+	CancelingStep  string
+	Error          error
+	ErrorCount     int
+	ErrorMethod    string
+	Order          []string
+	SetupPatchFunc func(p *Patch)
 
 	errorCount int
 }
@@ -570,11 +772,14 @@ func (r *testResource) NewUpdatePatch(ctx context.Context, obj, currentState, de
 		return nil, r.Error
 	}
 
-	// TODO test not invoking when patch part is not set.
 	p := NewPatch()
-	p.SetCreate("test create state")
-	p.SetUpdate("test update state")
-	p.SetDelete("test delete state")
+	if r.SetupPatchFunc != nil {
+		r.SetupPatchFunc(p)
+	} else {
+		p.SetCreate("test create data")
+		p.SetUpdate("test update data")
+		p.SetDelete("test delete data")
+	}
 	return p, nil
 }
 
@@ -593,11 +798,14 @@ func (r *testResource) NewDeletePatch(ctx context.Context, obj, currentState, de
 		return nil, r.Error
 	}
 
-	// TODO test not invoking when patch part is not set.
 	p := NewPatch()
-	p.SetCreate("test create state")
-	p.SetUpdate("test update state")
-	p.SetDelete("test delete state")
+	if r.SetupPatchFunc != nil {
+		r.SetupPatchFunc(p)
+	} else {
+		p.SetCreate("test create data")
+		p.SetUpdate("test update data")
+		p.SetDelete("test delete data")
+	}
 	return p, nil
 }
 
@@ -606,7 +814,7 @@ func (r *testResource) Name() string {
 }
 
 func (r *testResource) ApplyCreatePatch(ctx context.Context, obj, createState interface{}) error {
-	m := "Create"
+	m := "ApplyCreatePatch"
 	r.Order = append(r.Order, m)
 
 	if r.CancelingStep == m {
@@ -624,7 +832,7 @@ func (r *testResource) ApplyCreatePatch(ctx context.Context, obj, createState in
 }
 
 func (r *testResource) ApplyDeletePatch(ctx context.Context, obj, deleteState interface{}) error {
-	m := "Delete"
+	m := "ApplyDeletePatch"
 	r.Order = append(r.Order, m)
 
 	if r.CancelingStep == m {
@@ -642,7 +850,7 @@ func (r *testResource) ApplyDeletePatch(ctx context.Context, obj, deleteState in
 }
 
 func (r *testResource) ApplyUpdatePatch(ctx context.Context, obj, updateState interface{}) error {
-	m := "Update"
+	m := "ApplyUpdatePatch"
 	r.Order = append(r.Order, m)
 
 	if r.CancelingStep == m {

--- a/framework/framework_test.go
+++ b/framework/framework_test.go
@@ -40,8 +40,10 @@ func Test_Framework_ProcessCreate_ResourceOrder(t *testing.T) {
 				{
 					"GetCurrentState",
 					"GetDesiredState",
-					"GetCreateState",
-					"ProcessCreateState",
+					"NewUpdatePatch",
+					"Create",
+					"Delete",
+					"Update",
 				},
 			},
 			ErrorMatcher: nil,
@@ -60,14 +62,18 @@ func Test_Framework_ProcessCreate_ResourceOrder(t *testing.T) {
 				{
 					"GetCurrentState",
 					"GetDesiredState",
-					"GetCreateState",
-					"ProcessCreateState",
+					"NewUpdatePatch",
+					"Create",
+					"Delete",
+					"Update",
 				},
 				{
 					"GetCurrentState",
 					"GetDesiredState",
-					"GetCreateState",
-					"ProcessCreateState",
+					"NewUpdatePatch",
+					"Create",
+					"Delete",
+					"Update",
 				},
 			},
 			ErrorMatcher: nil,
@@ -106,8 +112,10 @@ func Test_Framework_ProcessCreate_ResourceOrder(t *testing.T) {
 				{
 					"GetCurrentState",
 					"GetDesiredState",
-					"GetCreateState",
-					"ProcessCreateState",
+					"NewUpdatePatch",
+					"Create",
+					"Delete",
+					"Update",
 				},
 			},
 			ErrorMatcher: nil,
@@ -121,7 +129,7 @@ func Test_Framework_ProcessCreate_ResourceOrder(t *testing.T) {
 			Ctx:           canceledcontext.NewContext(context.Background(), make(chan struct{})),
 			Resources: []Resource{
 				&testResource{
-					CancelingStep: "GetCreateState",
+					CancelingStep: "NewUpdatePatch",
 				},
 				&testResource{},
 			},
@@ -129,7 +137,7 @@ func Test_Framework_ProcessCreate_ResourceOrder(t *testing.T) {
 				{
 					"GetCurrentState",
 					"GetDesiredState",
-					"GetCreateState",
+					"NewUpdatePatch",
 				},
 				nil,
 			},
@@ -145,20 +153,22 @@ func Test_Framework_ProcessCreate_ResourceOrder(t *testing.T) {
 			Resources: []Resource{
 				&testResource{},
 				&testResource{
-					CancelingStep: "GetCreateState",
+					CancelingStep: "NewUpdatePatch",
 				},
 			},
 			ExpectedOrders: [][]string{
 				{
 					"GetCurrentState",
 					"GetDesiredState",
-					"GetCreateState",
-					"ProcessCreateState",
+					"NewUpdatePatch",
+					"Create",
+					"Delete",
+					"Update",
 				},
 				{
 					"GetCurrentState",
 					"GetDesiredState",
-					"GetCreateState",
+					"NewUpdatePatch",
 				},
 			},
 			ErrorMatcher: nil,
@@ -185,9 +195,10 @@ func Test_Framework_ProcessCreate_ResourceOrder(t *testing.T) {
 			ExpectedOrders: [][]string{
 				{
 					"GetCurrentState",
-					"GetDesiredState",
-					"GetDeleteState",
-					"ProcessDeleteState",
+					"NewDeletePatch",
+					"Create",
+					"Delete",
+					"Update",
 				},
 			},
 			ErrorMatcher: nil,
@@ -205,15 +216,17 @@ func Test_Framework_ProcessCreate_ResourceOrder(t *testing.T) {
 			ExpectedOrders: [][]string{
 				{
 					"GetCurrentState",
-					"GetDesiredState",
-					"GetDeleteState",
-					"ProcessDeleteState",
+					"NewDeletePatch",
+					"Create",
+					"Delete",
+					"Update",
 				},
 				{
 					"GetCurrentState",
-					"GetDesiredState",
-					"GetDeleteState",
-					"ProcessDeleteState",
+					"NewDeletePatch",
+					"Create",
+					"Delete",
+					"Update",
 				},
 			},
 			ErrorMatcher: nil,
@@ -251,9 +264,10 @@ func Test_Framework_ProcessCreate_ResourceOrder(t *testing.T) {
 			ExpectedOrders: [][]string{
 				{
 					"GetCurrentState",
-					"GetDesiredState",
-					"GetDeleteState",
-					"ProcessDeleteState",
+					"NewDeletePatch",
+					"Create",
+					"Delete",
+					"Update",
 				},
 			},
 			ErrorMatcher: nil,
@@ -267,15 +281,14 @@ func Test_Framework_ProcessCreate_ResourceOrder(t *testing.T) {
 			Ctx:           canceledcontext.NewContext(context.Background(), make(chan struct{})),
 			Resources: []Resource{
 				&testResource{
-					CancelingStep: "GetDeleteState",
+					CancelingStep: "NewDeletePatch",
 				},
 				&testResource{},
 			},
 			ExpectedOrders: [][]string{
 				{
 					"GetCurrentState",
-					"GetDesiredState",
-					"GetDeleteState",
+					"NewDeletePatch",
 				},
 				nil,
 			},
@@ -291,20 +304,20 @@ func Test_Framework_ProcessCreate_ResourceOrder(t *testing.T) {
 			Resources: []Resource{
 				&testResource{},
 				&testResource{
-					CancelingStep: "GetDeleteState",
+					CancelingStep: "NewDeletePatch",
 				},
 			},
 			ExpectedOrders: [][]string{
 				{
 					"GetCurrentState",
-					"GetDesiredState",
-					"GetDeleteState",
-					"ProcessDeleteState",
+					"NewDeletePatch",
+					"Create",
+					"Delete",
+					"Update",
 				},
 				{
 					"GetCurrentState",
-					"GetDesiredState",
-					"GetDeleteState",
+					"NewDeletePatch",
 				},
 			},
 			ErrorMatcher: nil,
@@ -332,10 +345,10 @@ func Test_Framework_ProcessCreate_ResourceOrder(t *testing.T) {
 				{
 					"GetCurrentState",
 					"GetDesiredState",
-					"GetUpdateState",
-					"ProcessCreateState",
-					"ProcessDeleteState",
-					"ProcessUpdateState",
+					"NewUpdatePatch",
+					"Create",
+					"Delete",
+					"Update",
 				},
 			},
 			ErrorMatcher: nil,
@@ -354,18 +367,18 @@ func Test_Framework_ProcessCreate_ResourceOrder(t *testing.T) {
 				{
 					"GetCurrentState",
 					"GetDesiredState",
-					"GetUpdateState",
-					"ProcessCreateState",
-					"ProcessDeleteState",
-					"ProcessUpdateState",
+					"NewUpdatePatch",
+					"Create",
+					"Delete",
+					"Update",
 				},
 				{
 					"GetCurrentState",
 					"GetDesiredState",
-					"GetUpdateState",
-					"ProcessCreateState",
-					"ProcessDeleteState",
-					"ProcessUpdateState",
+					"NewUpdatePatch",
+					"Create",
+					"Delete",
+					"Update",
 				},
 			},
 			ErrorMatcher: nil,
@@ -404,10 +417,10 @@ func Test_Framework_ProcessCreate_ResourceOrder(t *testing.T) {
 				{
 					"GetCurrentState",
 					"GetDesiredState",
-					"GetUpdateState",
-					"ProcessCreateState",
-					"ProcessDeleteState",
-					"ProcessUpdateState",
+					"NewUpdatePatch",
+					"Create",
+					"Delete",
+					"Update",
 				},
 			},
 			ErrorMatcher: nil,
@@ -421,7 +434,7 @@ func Test_Framework_ProcessCreate_ResourceOrder(t *testing.T) {
 			Ctx:           canceledcontext.NewContext(context.Background(), make(chan struct{})),
 			Resources: []Resource{
 				&testResource{
-					CancelingStep: "GetUpdateState",
+					CancelingStep: "NewUpdatePatch",
 				},
 				&testResource{},
 			},
@@ -429,7 +442,7 @@ func Test_Framework_ProcessCreate_ResourceOrder(t *testing.T) {
 				{
 					"GetCurrentState",
 					"GetDesiredState",
-					"GetUpdateState",
+					"NewUpdatePatch",
 				},
 				nil,
 			},
@@ -445,22 +458,22 @@ func Test_Framework_ProcessCreate_ResourceOrder(t *testing.T) {
 			Resources: []Resource{
 				&testResource{},
 				&testResource{
-					CancelingStep: "GetUpdateState",
+					CancelingStep: "NewUpdatePatch",
 				},
 			},
 			ExpectedOrders: [][]string{
 				{
 					"GetCurrentState",
 					"GetDesiredState",
-					"GetUpdateState",
-					"ProcessCreateState",
-					"ProcessDeleteState",
-					"ProcessUpdateState",
+					"NewUpdatePatch",
+					"Create",
+					"Delete",
+					"Update",
 				},
 				{
 					"GetCurrentState",
 					"GetDesiredState",
-					"GetUpdateState",
+					"NewUpdatePatch",
 				},
 			},
 			ErrorMatcher: nil,
@@ -535,8 +548,8 @@ func (r *testResource) GetDesiredState(ctx context.Context, obj interface{}) (in
 	return nil, nil
 }
 
-func (r *testResource) GetCreateState(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
-	m := "GetCreateState"
+func (r *testResource) NewUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*Patch, error) {
+	m := "NewUpdatePatch"
 	r.Order = append(r.Order, m)
 
 	if r.CancelingStep == m {
@@ -550,11 +563,16 @@ func (r *testResource) GetCreateState(ctx context.Context, obj, currentState, de
 		return nil, r.Error
 	}
 
-	return nil, nil
+	// TODO test not invoking when patch part is not set.
+	p := NewPatch()
+	p.SetCreate("test create state")
+	p.SetUpdate("test update state")
+	p.SetDelete("test delete state")
+	return p, nil
 }
 
-func (r *testResource) GetDeleteState(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
-	m := "GetDeleteState"
+func (r *testResource) NewDeletePatch(ctx context.Context, obj, currentState interface{}) (*Patch, error) {
+	m := "NewDeletePatch"
 	r.Order = append(r.Order, m)
 
 	if r.CancelingStep == m {
@@ -568,33 +586,20 @@ func (r *testResource) GetDeleteState(ctx context.Context, obj, currentState, de
 		return nil, r.Error
 	}
 
-	return nil, nil
-}
-
-func (r *testResource) GetUpdateState(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, interface{}, interface{}, error) {
-	m := "GetUpdateState"
-	r.Order = append(r.Order, m)
-
-	if r.CancelingStep == m {
-		canceledcontext.SetCanceled(ctx)
-		if canceledcontext.IsCanceled(ctx) {
-			return nil, nil, nil, nil
-		}
-	}
-
-	if r.returnErrorFor(m) {
-		return nil, nil, nil, r.Error
-	}
-
-	return nil, nil, nil, nil
+	// TODO test not invoking when patch part is not set.
+	p := NewPatch()
+	p.SetCreate("test create state")
+	p.SetUpdate("test update state")
+	p.SetDelete("test delete state")
+	return p, nil
 }
 
 func (r *testResource) Name() string {
 	return "testResource"
 }
 
-func (r *testResource) ProcessCreateState(ctx context.Context, obj, createState interface{}) error {
-	m := "ProcessCreateState"
+func (r *testResource) Create(ctx context.Context, obj, createState interface{}) error {
+	m := "Create"
 	r.Order = append(r.Order, m)
 
 	if r.CancelingStep == m {
@@ -611,8 +616,8 @@ func (r *testResource) ProcessCreateState(ctx context.Context, obj, createState 
 	return nil
 }
 
-func (r *testResource) ProcessDeleteState(ctx context.Context, obj, deleteState interface{}) error {
-	m := "ProcessDeleteState"
+func (r *testResource) Delete(ctx context.Context, obj, deleteState interface{}) error {
+	m := "Delete"
 	r.Order = append(r.Order, m)
 
 	if r.CancelingStep == m {
@@ -629,8 +634,8 @@ func (r *testResource) ProcessDeleteState(ctx context.Context, obj, deleteState 
 	return nil
 }
 
-func (r *testResource) ProcessUpdateState(ctx context.Context, obj, updateState interface{}) error {
-	m := "ProcessUpdateState"
+func (r *testResource) Update(ctx context.Context, obj, updateState interface{}) error {
+	m := "Update"
 	r.Order = append(r.Order, m)
 
 	if r.CancelingStep == m {

--- a/framework/framework_test.go
+++ b/framework/framework_test.go
@@ -498,23 +498,23 @@ func Test_Framework_ResourceCallOrder(t *testing.T) {
 				},
 				&testResource{
 					SetupPatchFunc: func(p *Patch) {
-						p.SetCreate("test create data")
+						p.SetCreateChange("test create data")
 					},
 				},
 				&testResource{
 					SetupPatchFunc: func(p *Patch) {
-						p.SetDelete("test delete data")
+						p.SetDeleteChange("test delete data")
 					},
 				},
 				&testResource{
 					SetupPatchFunc: func(p *Patch) {
-						p.SetUpdate("test update data")
+						p.SetUpdateChange("test update data")
 					},
 				},
 				&testResource{
 					SetupPatchFunc: func(p *Patch) {
-						p.SetCreate("test create data")
-						p.SetDelete("test delete data")
+						p.SetCreateChange("test create data")
+						p.SetDeleteChange("test delete data")
 					},
 				},
 			},
@@ -565,23 +565,23 @@ func Test_Framework_ResourceCallOrder(t *testing.T) {
 				},
 				&testResource{
 					SetupPatchFunc: func(p *Patch) {
-						p.SetCreate("test create data")
+						p.SetCreateChange("test create data")
 					},
 				},
 				&testResource{
 					SetupPatchFunc: func(p *Patch) {
-						p.SetDelete("test delete data")
+						p.SetDeleteChange("test delete data")
 					},
 				},
 				&testResource{
 					SetupPatchFunc: func(p *Patch) {
-						p.SetUpdate("test update data")
+						p.SetUpdateChange("test update data")
 					},
 				},
 				&testResource{
 					SetupPatchFunc: func(p *Patch) {
-						p.SetCreate("test create data")
-						p.SetDelete("test delete data")
+						p.SetCreateChange("test create data")
+						p.SetDeleteChange("test delete data")
 					},
 				},
 			},
@@ -632,23 +632,23 @@ func Test_Framework_ResourceCallOrder(t *testing.T) {
 				},
 				&testResource{
 					SetupPatchFunc: func(p *Patch) {
-						p.SetCreate("test create data")
+						p.SetCreateChange("test create data")
 					},
 				},
 				&testResource{
 					SetupPatchFunc: func(p *Patch) {
-						p.SetDelete("test delete data")
+						p.SetDeleteChange("test delete data")
 					},
 				},
 				&testResource{
 					SetupPatchFunc: func(p *Patch) {
-						p.SetUpdate("test update data")
+						p.SetUpdateChange("test update data")
 					},
 				},
 				&testResource{
 					SetupPatchFunc: func(p *Patch) {
-						p.SetCreate("test create data")
-						p.SetDelete("test delete data")
+						p.SetCreateChange("test create data")
+						p.SetDeleteChange("test delete data")
 					},
 				},
 			},
@@ -776,9 +776,9 @@ func (r *testResource) NewUpdatePatch(ctx context.Context, obj, currentState, de
 	if r.SetupPatchFunc != nil {
 		r.SetupPatchFunc(p)
 	} else {
-		p.SetCreate("test create data")
-		p.SetUpdate("test update data")
-		p.SetDelete("test delete data")
+		p.SetCreateChange("test create data")
+		p.SetUpdateChange("test update data")
+		p.SetDeleteChange("test delete data")
 	}
 	return p, nil
 }
@@ -802,9 +802,9 @@ func (r *testResource) NewDeletePatch(ctx context.Context, obj, currentState, de
 	if r.SetupPatchFunc != nil {
 		r.SetupPatchFunc(p)
 	} else {
-		p.SetCreate("test create data")
-		p.SetUpdate("test update data")
-		p.SetDelete("test delete data")
+		p.SetCreateChange("test create data")
+		p.SetUpdateChange("test update data")
+		p.SetDeleteChange("test delete data")
 	}
 	return p, nil
 }
@@ -813,7 +813,7 @@ func (r *testResource) Name() string {
 	return "testResource"
 }
 
-func (r *testResource) ApplyCreatePatch(ctx context.Context, obj, createState interface{}) error {
+func (r *testResource) ApplyCreateChange(ctx context.Context, obj, createState interface{}) error {
 	m := "ApplyCreatePatch"
 	r.Order = append(r.Order, m)
 
@@ -831,7 +831,7 @@ func (r *testResource) ApplyCreatePatch(ctx context.Context, obj, createState in
 	return nil
 }
 
-func (r *testResource) ApplyDeletePatch(ctx context.Context, obj, deleteState interface{}) error {
+func (r *testResource) ApplyDeleteChange(ctx context.Context, obj, deleteState interface{}) error {
 	m := "ApplyDeletePatch"
 	r.Order = append(r.Order, m)
 
@@ -849,7 +849,7 @@ func (r *testResource) ApplyDeletePatch(ctx context.Context, obj, deleteState in
 	return nil
 }
 
-func (r *testResource) ApplyUpdatePatch(ctx context.Context, obj, updateState interface{}) error {
+func (r *testResource) ApplyUpdateChange(ctx context.Context, obj, updateState interface{}) error {
 	m := "ApplyUpdatePatch"
 	r.Order = append(r.Order, m)
 

--- a/framework/framework_test.go
+++ b/framework/framework_test.go
@@ -195,6 +195,7 @@ func Test_Framework_ProcessCreate_ResourceOrder(t *testing.T) {
 			ExpectedOrders: [][]string{
 				{
 					"GetCurrentState",
+					"GetDesiredState",
 					"NewDeletePatch",
 					"Create",
 					"Delete",
@@ -216,6 +217,7 @@ func Test_Framework_ProcessCreate_ResourceOrder(t *testing.T) {
 			ExpectedOrders: [][]string{
 				{
 					"GetCurrentState",
+					"GetDesiredState",
 					"NewDeletePatch",
 					"Create",
 					"Delete",
@@ -223,6 +225,7 @@ func Test_Framework_ProcessCreate_ResourceOrder(t *testing.T) {
 				},
 				{
 					"GetCurrentState",
+					"GetDesiredState",
 					"NewDeletePatch",
 					"Create",
 					"Delete",
@@ -264,6 +267,7 @@ func Test_Framework_ProcessCreate_ResourceOrder(t *testing.T) {
 			ExpectedOrders: [][]string{
 				{
 					"GetCurrentState",
+					"GetDesiredState",
 					"NewDeletePatch",
 					"Create",
 					"Delete",
@@ -288,6 +292,7 @@ func Test_Framework_ProcessCreate_ResourceOrder(t *testing.T) {
 			ExpectedOrders: [][]string{
 				{
 					"GetCurrentState",
+					"GetDesiredState",
 					"NewDeletePatch",
 				},
 				nil,
@@ -310,6 +315,7 @@ func Test_Framework_ProcessCreate_ResourceOrder(t *testing.T) {
 			ExpectedOrders: [][]string{
 				{
 					"GetCurrentState",
+					"GetDesiredState",
 					"NewDeletePatch",
 					"Create",
 					"Delete",
@@ -317,6 +323,7 @@ func Test_Framework_ProcessCreate_ResourceOrder(t *testing.T) {
 				},
 				{
 					"GetCurrentState",
+					"GetDesiredState",
 					"NewDeletePatch",
 				},
 			},
@@ -571,7 +578,7 @@ func (r *testResource) NewUpdatePatch(ctx context.Context, obj, currentState, de
 	return p, nil
 }
 
-func (r *testResource) NewDeletePatch(ctx context.Context, obj, currentState interface{}) (*Patch, error) {
+func (r *testResource) NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*Patch, error) {
 	m := "NewDeletePatch"
 	r.Order = append(r.Order, m)
 
@@ -598,7 +605,7 @@ func (r *testResource) Name() string {
 	return "testResource"
 }
 
-func (r *testResource) Create(ctx context.Context, obj, createState interface{}) error {
+func (r *testResource) ApplyCreatePatch(ctx context.Context, obj, createState interface{}) error {
 	m := "Create"
 	r.Order = append(r.Order, m)
 
@@ -616,7 +623,7 @@ func (r *testResource) Create(ctx context.Context, obj, createState interface{})
 	return nil
 }
 
-func (r *testResource) Delete(ctx context.Context, obj, deleteState interface{}) error {
+func (r *testResource) ApplyDeletePatch(ctx context.Context, obj, deleteState interface{}) error {
 	m := "Delete"
 	r.Order = append(r.Order, m)
 
@@ -634,7 +641,7 @@ func (r *testResource) Delete(ctx context.Context, obj, deleteState interface{})
 	return nil
 }
 
-func (r *testResource) Update(ctx context.Context, obj, updateState interface{}) error {
+func (r *testResource) ApplyUpdatePatch(ctx context.Context, obj, updateState interface{}) error {
 	m := "Update"
 	r.Order = append(r.Order, m)
 

--- a/framework/patch.go
+++ b/framework/patch.go
@@ -9,10 +9,11 @@ const (
 )
 
 // Patch is a set of information required in order to reconcile to the desired
-// state. Patch is split into three parts: create, delete and update. The parts
-// are passed as arguments to Resource's Create, Delete and Update functions
-// respectively. Patch is guaranteed to be applied in that order (i.e. create,
-// update, delete).
+// state. Patch is split into three parts: create, delete and update changes.
+// The parts are passed as arguments to Resource's ApplyCreateChange,
+// ApplyDeleteChange and ApplyUpdateChange functions respectively. Patch
+// changes are guaranteed to be applied in that order (i.e. create, update,
+// delete).
 type Patch struct {
 	data map[patchType]interface{}
 }
@@ -23,20 +24,20 @@ func NewPatch() *Patch {
 	}
 }
 
-func (p *Patch) getCreate() (interface{}, bool) {
+func (p *Patch) getCreateChange() (interface{}, bool) {
 	create, ok := p.data[patchCreate]
 	return create, ok
 }
 
-func (p *Patch) getDelete() (interface{}, bool) {
+func (p *Patch) getDeleteChange() (interface{}, bool) {
 	delete, ok := p.data[patchDelete]
 	return delete, ok
 }
-func (p *Patch) getUpdate() (interface{}, bool) {
+func (p *Patch) getUpdateChange() (interface{}, bool) {
 	update, ok := p.data[patchUpdate]
 	return update, ok
 }
 
-func (p *Patch) SetCreate(create interface{}) { p.data[patchCreate] = create }
-func (p *Patch) SetDelete(delete interface{}) { p.data[patchDelete] = delete }
-func (p *Patch) SetUpdate(update interface{}) { p.data[patchUpdate] = update }
+func (p *Patch) SetCreateChange(create interface{}) { p.data[patchCreate] = create }
+func (p *Patch) SetDeleteChange(delete interface{}) { p.data[patchDelete] = delete }
+func (p *Patch) SetUpdateChange(update interface{}) { p.data[patchUpdate] = update }

--- a/framework/patch.go
+++ b/framework/patch.go
@@ -1,0 +1,42 @@
+package framework
+
+type patchType string
+
+const (
+	patchCreate patchType = "create"
+	patchDelete patchType = "delete"
+	patchUpdate patchType = "update"
+)
+
+// Patch is a set of information required in order to reconcile to the desired
+// state. Patch is split into three parts: create, delete and update. The parts
+// are passed as arguments to Resource's Create, Delete and Update functions
+// respectively. Patch is guaranteed to be applied in that order (i.e. create,
+// update, delete).
+type Patch struct {
+	data map[patchType]interface{}
+}
+
+func NewPatch() *Patch {
+	return &Patch{
+		data: make(map[patchType]interface{}, 3),
+	}
+}
+
+func (p *Patch) getCreate() (interface{}, bool) {
+	create, ok := p.data[patchCreate]
+	return create, ok
+}
+
+func (p *Patch) getDelete() (interface{}, bool) {
+	delete, ok := p.data[patchDelete]
+	return delete, ok
+}
+func (p *Patch) getUpdate() (interface{}, bool) {
+	update, ok := p.data[patchUpdate]
+	return update, ok
+}
+
+func (p *Patch) SetCreate(create interface{}) { p.data[patchCreate] = create }
+func (p *Patch) SetDelete(delete interface{}) { p.data[patchDelete] = delete }
+func (p *Patch) SetUpdate(update interface{}) { p.data[patchUpdate] = update }

--- a/framework/resource/logresource/resource.go
+++ b/framework/resource/logresource/resource.go
@@ -116,10 +116,10 @@ func (r *Resource) Name() string {
 	return Name
 }
 
-func (r *Resource) ApplyCreatePatch(ctx context.Context, obj, cre interface{}) error {
+func (r *Resource) ApplyCreateChange(ctx context.Context, obj, cre interface{}) error {
 	r.logger.Log("action", "start", "component", "operatorkit", "function", "ApplyCreatePatch")
 
-	err := r.resource.ApplyCreatePatch(ctx, obj, cre)
+	err := r.resource.ApplyCreateChange(ctx, obj, cre)
 	if err != nil {
 		return microerror.Mask(err)
 	}
@@ -129,10 +129,10 @@ func (r *Resource) ApplyCreatePatch(ctx context.Context, obj, cre interface{}) e
 	return nil
 }
 
-func (r *Resource) ApplyDeletePatch(ctx context.Context, obj, del interface{}) error {
+func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, del interface{}) error {
 	r.logger.Log("action", "start", "component", "operatorkit", "function", "ApplyDeletePatch")
 
-	err := r.resource.ApplyDeletePatch(ctx, obj, del)
+	err := r.resource.ApplyDeleteChange(ctx, obj, del)
 	if err != nil {
 		return microerror.Mask(err)
 	}
@@ -142,10 +142,10 @@ func (r *Resource) ApplyDeletePatch(ctx context.Context, obj, del interface{}) e
 	return nil
 }
 
-func (r *Resource) ApplyUpdatePatch(ctx context.Context, obj, upd interface{}) error {
+func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, upd interface{}) error {
 	r.logger.Log("action", "start", "component", "operatorkit", "function", "ApplyUpdatePatch")
 
-	err := r.resource.ApplyUpdatePatch(ctx, obj, upd)
+	err := r.resource.ApplyUpdateChange(ctx, obj, upd)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/framework/resource/logresource/resource.go
+++ b/framework/resource/logresource/resource.go
@@ -86,84 +86,71 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 	return v, nil
 }
 
-func (r *Resource) GetCreateState(ctx context.Context, obj, cur, des interface{}) (interface{}, error) {
-	r.logger.Log("action", "start", "component", "operatorkit", "function", "GetCreateState")
+func (r *Resource) NewUpdatePatch(ctx context.Context, obj, cur, des interface{}) (*framework.Patch, error) {
+	r.logger.Log("action", "start", "component", "operatorkit", "function", "NewUpdatePatch")
 
-	v, err := r.resource.GetCreateState(ctx, obj, cur, des)
+	v, err := r.resource.NewUpdatePatch(ctx, obj, cur, des)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
 
-	r.logger.Log("action", "end", "component", "operatorkit", "function", "GetCreateState")
+	r.logger.Log("action", "end", "component", "operatorkit", "function", "NewUpdatePatch")
 
 	return v, nil
 }
 
-func (r *Resource) GetDeleteState(ctx context.Context, obj, cur, des interface{}) (interface{}, error) {
-	r.logger.Log("action", "start", "component", "operatorkit", "function", "GetDeleteState")
+func (r *Resource) NewDeletePatch(ctx context.Context, obj, cur, des interface{}) (*framework.Patch, error) {
+	r.logger.Log("action", "start", "component", "operatorkit", "function", "NewDeletePatch")
 
-	v, err := r.resource.GetDeleteState(ctx, obj, cur, des)
+	v, err := r.resource.NewDeletePatch(ctx, obj, cur, des)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
 
-	r.logger.Log("action", "end", "component", "operatorkit", "function", "GetDeleteState")
+	r.logger.Log("action", "end", "component", "operatorkit", "function", "NewDeletePatch")
 
 	return v, nil
-}
-
-func (r *Resource) GetUpdateState(ctx context.Context, obj, cur, des interface{}) (interface{}, interface{}, interface{}, error) {
-	r.logger.Log("action", "start", "component", "operatorkit", "function", "GetUpdateState")
-
-	createState, deleteState, updateState, err := r.resource.GetUpdateState(ctx, obj, cur, des)
-	if err != nil {
-		return nil, nil, nil, microerror.Mask(err)
-	}
-
-	r.logger.Log("action", "end", "component", "operatorkit", "function", "GetUpdateState")
-
-	return createState, deleteState, updateState, nil
 }
 
 func (r *Resource) Name() string {
 	return Name
 }
 
-func (r *Resource) ProcessCreateState(ctx context.Context, obj, cre interface{}) error {
-	r.logger.Log("action", "start", "component", "operatorkit", "function", "ProcessCreateState")
+func (r *Resource) ApplyCreatePatch(ctx context.Context, obj, cre interface{}) error {
+	r.logger.Log("action", "start", "component", "operatorkit", "function", "ApplyCreatePatch")
 
-	err := r.resource.ProcessCreateState(ctx, obj, cre)
+	err := r.resource.ApplyCreatePatch(ctx, obj, cre)
 	if err != nil {
 		return microerror.Mask(err)
 	}
 
-	r.logger.Log("action", "end", "component", "operatorkit", "function", "ProcessCreateState")
+	r.logger.Log("action", "end", "component", "operatorkit", "function", "ApplyCreatePatch")
 
 	return nil
 }
 
-func (r *Resource) ProcessDeleteState(ctx context.Context, obj, del interface{}) error {
-	r.logger.Log("action", "start", "component", "operatorkit", "function", "ProcessDeleteState")
+func (r *Resource) ApplyDeletePatch(ctx context.Context, obj, del interface{}) error {
+	r.logger.Log("action", "start", "component", "operatorkit", "function", "ApplyDeletePatch")
 
-	err := r.resource.ProcessDeleteState(ctx, obj, del)
+	err := r.resource.ApplyDeletePatch(ctx, obj, del)
 	if err != nil {
 		return microerror.Mask(err)
 	}
 
-	r.logger.Log("action", "end", "component", "operatorkit", "function", "ProcessDeleteState")
+	r.logger.Log("action", "end", "component", "operatorkit", "function", "ApplyDeletePatch")
 
 	return nil
 }
 
-func (r *Resource) ProcessUpdateState(ctx context.Context, obj, upd interface{}) error {
-	r.logger.Log("action", "start", "component", "operatorkit", "function", "ProcessUpdateState")
+func (r *Resource) ApplyUpdatePatch(ctx context.Context, obj, upd interface{}) error {
+	r.logger.Log("action", "start", "component", "operatorkit", "function", "ApplyUpdatePatch")
 
-	err := r.resource.ProcessUpdateState(ctx, obj, upd)
+	err := r.resource.ApplyUpdatePatch(ctx, obj, upd)
 	if err != nil {
 		return microerror.Mask(err)
 	}
 
-	r.logger.Log("action", "end", "component", "operatorkit", "function", "ProcessUpdateState")
+	r.logger.Log("action", "end", "component", "operatorkit", "function", "ApplyUpdatePatch")
 
 	return nil
 }

--- a/framework/resource/logresource/resource_test.go
+++ b/framework/resource/logresource/resource_test.go
@@ -286,9 +286,9 @@ func (r *testResource) NewUpdatePatch(ctx context.Context, obj, cur, des interfa
 	r.Order = append(r.Order, m)
 
 	p := framework.NewPatch()
-	p.SetCreate("test create data")
-	p.SetUpdate("test update data")
-	p.SetDelete("test delete data")
+	p.SetCreateChange("test create data")
+	p.SetUpdateChange("test update data")
+	p.SetDeleteChange("test delete data")
 	return p, nil
 }
 
@@ -297,9 +297,9 @@ func (r *testResource) NewDeletePatch(ctx context.Context, obj, cur, des interfa
 	r.Order = append(r.Order, m)
 
 	p := framework.NewPatch()
-	p.SetCreate("test create data")
-	p.SetUpdate("test update data")
-	p.SetDelete("test delete data")
+	p.SetCreateChange("test create data")
+	p.SetUpdateChange("test update data")
+	p.SetDeleteChange("test delete data")
 	return p, nil
 }
 
@@ -307,21 +307,21 @@ func (r *testResource) Name() string {
 	return "testResource"
 }
 
-func (r *testResource) ApplyCreatePatch(ctx context.Context, obj, cre interface{}) error {
+func (r *testResource) ApplyCreateChange(ctx context.Context, obj, cre interface{}) error {
 	m := "ApplyCreatePatch"
 	r.Order = append(r.Order, m)
 
 	return nil
 }
 
-func (r *testResource) ApplyDeletePatch(ctx context.Context, obj, del interface{}) error {
+func (r *testResource) ApplyDeleteChange(ctx context.Context, obj, del interface{}) error {
 	m := "ApplyDeletePatch"
 	r.Order = append(r.Order, m)
 
 	return nil
 }
 
-func (r *testResource) ApplyUpdatePatch(ctx context.Context, obj, updateState interface{}) error {
+func (r *testResource) ApplyUpdateChange(ctx context.Context, obj, updateState interface{}) error {
 	m := "ApplyUpdatePatch"
 	r.Order = append(r.Order, m)
 

--- a/framework/resource/logresource/resource_test.go
+++ b/framework/resource/logresource/resource_test.go
@@ -49,8 +49,10 @@ func Test_LogResource_ProcessCreate_ResourceOrder(t *testing.T) {
 		e := []string{
 			"GetCurrentState",
 			"GetDesiredState",
-			"GetCreateState",
-			"ProcessCreateState",
+			"NewUpdatePatch",
+			"ApplyCreatePatch",
+			"ApplyDeletePatch",
+			"ApplyUpdatePatch",
 		}
 		if !reflect.DeepEqual(e, tr.Order) {
 			t.Fatal("expected", e, "got", tr.Order)
@@ -64,10 +66,10 @@ func Test_LogResource_ProcessCreate_ResourceOrder(t *testing.T) {
 			"GetCurrentState",
 			"GetDesiredState",
 			"GetDesiredState",
-			"GetCreateState",
-			"GetCreateState",
-			"ProcessCreateState",
-			"ProcessCreateState",
+			"NewUpdatePatch",
+			"NewUpdatePatch",
+			"ApplyCreatePatch",
+			"ApplyCreatePatch",
 		}
 		scanner := bufio.NewScanner(out)
 		for _, f := range fields {
@@ -128,8 +130,10 @@ func Test_LogResource_ProcessDelete_ResourceOrder(t *testing.T) {
 		e := []string{
 			"GetCurrentState",
 			"GetDesiredState",
-			"GetDeleteState",
-			"ProcessDeleteState",
+			"NewDeletePatch",
+			"ApplyCreatePatch",
+			"ApplyDeletePatch",
+			"ApplyUpdatePatch",
 		}
 		if !reflect.DeepEqual(e, tr.Order) {
 			t.Fatal("expected", e, "got", tr.Order)
@@ -143,10 +147,14 @@ func Test_LogResource_ProcessDelete_ResourceOrder(t *testing.T) {
 			"GetCurrentState",
 			"GetDesiredState",
 			"GetDesiredState",
-			"GetDeleteState",
-			"GetDeleteState",
-			"ProcessDeleteState",
-			"ProcessDeleteState",
+			"NewDeletePatch",
+			"NewDeletePatch",
+			"ApplyCreatePatch",
+			"ApplyCreatePatch",
+			"ApplyDeletePatch",
+			"ApplyDeletePatch",
+			"ApplyUpdatePatch",
+			"ApplyUpdatePatch",
 		}
 		scanner := bufio.NewScanner(out)
 		for _, f := range fields {
@@ -207,10 +215,10 @@ func Test_LogResource_ProcessUpdate_ResourceOrder(t *testing.T) {
 		e := []string{
 			"GetCurrentState",
 			"GetDesiredState",
-			"GetUpdateState",
-			"ProcessCreateState",
-			"ProcessDeleteState",
-			"ProcessUpdateState",
+			"NewUpdatePatch",
+			"ApplyCreatePatch",
+			"ApplyDeletePatch",
+			"ApplyUpdatePatch",
 		}
 		if !reflect.DeepEqual(e, tr.Order) {
 			t.Fatal("expected", e, "got", tr.Order)
@@ -224,14 +232,14 @@ func Test_LogResource_ProcessUpdate_ResourceOrder(t *testing.T) {
 			"GetCurrentState",
 			"GetDesiredState",
 			"GetDesiredState",
-			"GetUpdateState",
-			"GetUpdateState",
-			"ProcessCreateState",
-			"ProcessCreateState",
-			"ProcessDeleteState",
-			"ProcessDeleteState",
-			"ProcessUpdateState",
-			"ProcessUpdateState",
+			"NewUpdatePatch",
+			"NewUpdatePatch",
+			"ApplyCreatePatch",
+			"ApplyCreatePatch",
+			"ApplyDeletePatch",
+			"ApplyDeletePatch",
+			"ApplyUpdatePatch",
+			"ApplyUpdatePatch",
 		}
 		scanner := bufio.NewScanner(out)
 		for _, f := range fields {
@@ -273,47 +281,48 @@ func (r *testResource) GetDesiredState(ctx context.Context, obj interface{}) (in
 	return nil, nil
 }
 
-func (r *testResource) GetCreateState(ctx context.Context, obj, cur, des interface{}) (interface{}, error) {
-	m := "GetCreateState"
+func (r *testResource) NewUpdatePatch(ctx context.Context, obj, cur, des interface{}) (*framework.Patch, error) {
+	m := "NewUpdatePatch"
 	r.Order = append(r.Order, m)
 
-	return nil, nil
+	p := framework.NewPatch()
+	p.SetCreate("test create data")
+	p.SetUpdate("test update data")
+	p.SetDelete("test delete data")
+	return p, nil
 }
 
-func (r *testResource) GetDeleteState(ctx context.Context, obj, cur, des interface{}) (interface{}, error) {
-	m := "GetDeleteState"
+func (r *testResource) NewDeletePatch(ctx context.Context, obj, cur, des interface{}) (*framework.Patch, error) {
+	m := "NewDeletePatch"
 	r.Order = append(r.Order, m)
 
-	return nil, nil
-}
-
-func (r *testResource) GetUpdateState(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, interface{}, interface{}, error) {
-	m := "GetUpdateState"
-	r.Order = append(r.Order, m)
-
-	return nil, nil, nil, nil
+	p := framework.NewPatch()
+	p.SetCreate("test create data")
+	p.SetUpdate("test update data")
+	p.SetDelete("test delete data")
+	return p, nil
 }
 
 func (r *testResource) Name() string {
 	return "testResource"
 }
 
-func (r *testResource) ProcessCreateState(ctx context.Context, obj, cre interface{}) error {
-	m := "ProcessCreateState"
+func (r *testResource) ApplyCreatePatch(ctx context.Context, obj, cre interface{}) error {
+	m := "ApplyCreatePatch"
 	r.Order = append(r.Order, m)
 
 	return nil
 }
 
-func (r *testResource) ProcessDeleteState(ctx context.Context, obj, del interface{}) error {
-	m := "ProcessDeleteState"
+func (r *testResource) ApplyDeletePatch(ctx context.Context, obj, del interface{}) error {
+	m := "ApplyDeletePatch"
 	r.Order = append(r.Order, m)
 
 	return nil
 }
 
-func (r *testResource) ProcessUpdateState(ctx context.Context, obj, updateState interface{}) error {
-	m := "ProcessUpdateState"
+func (r *testResource) ApplyUpdatePatch(ctx context.Context, obj, updateState interface{}) error {
+	m := "ApplyUpdatePatch"
 	r.Order = append(r.Order, m)
 
 	return nil

--- a/framework/resource/metricsresource/resource.go
+++ b/framework/resource/metricsresource/resource.go
@@ -130,12 +130,12 @@ func (r *Resource) Name() string {
 	return Name
 }
 
-func (r *Resource) ApplyCreatePatch(ctx context.Context, obj, createState interface{}) error {
+func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createState interface{}) error {
 	o := "ApplyCreatePatch"
 
 	defer r.updateMetrics(o, time.Now())
 
-	err := r.resource.ApplyCreatePatch(ctx, obj, createState)
+	err := r.resource.ApplyCreateChange(ctx, obj, createState)
 	if err != nil {
 		r.updateErrorMetrics(o)
 		return microerror.Mask(err)
@@ -144,12 +144,12 @@ func (r *Resource) ApplyCreatePatch(ctx context.Context, obj, createState interf
 	return nil
 }
 
-func (r *Resource) ApplyDeletePatch(ctx context.Context, obj, deleteState interface{}) error {
+func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteState interface{}) error {
 	o := "ApplyDeletePatch"
 
 	defer r.updateMetrics(o, time.Now())
 
-	err := r.resource.ApplyDeletePatch(ctx, obj, deleteState)
+	err := r.resource.ApplyDeleteChange(ctx, obj, deleteState)
 	if err != nil {
 		r.updateErrorMetrics(o)
 		return microerror.Mask(err)
@@ -158,12 +158,12 @@ func (r *Resource) ApplyDeletePatch(ctx context.Context, obj, deleteState interf
 	return nil
 }
 
-func (r *Resource) ApplyUpdatePatch(ctx context.Context, obj, updateState interface{}) error {
+func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateState interface{}) error {
 	o := "ApplyUpdatePatch"
 
 	defer r.updateMetrics(o, time.Now())
 
-	err := r.resource.ApplyUpdatePatch(ctx, obj, updateState)
+	err := r.resource.ApplyUpdateChange(ctx, obj, updateState)
 	if err != nil {
 		r.updateErrorMetrics(o)
 		return microerror.Mask(err)

--- a/framework/resource/metricsresource/resource.go
+++ b/framework/resource/metricsresource/resource.go
@@ -98,12 +98,12 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 	return v, nil
 }
 
-func (r *Resource) GetCreateState(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
-	o := "GetCreateState"
+func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*framework.Patch, error) {
+	o := "NewUpdatePatch"
 
 	defer r.updateMetrics(o, time.Now())
 
-	v, err := r.resource.GetCreateState(ctx, obj, currentState, desiredState)
+	v, err := r.resource.NewUpdatePatch(ctx, obj, currentState, desiredState)
 	if err != nil {
 		r.updateErrorMetrics(o)
 		return nil, microerror.Mask(err)
@@ -112,44 +112,30 @@ func (r *Resource) GetCreateState(ctx context.Context, obj, currentState, desire
 	return v, nil
 }
 
-func (r *Resource) GetDeleteState(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
-	o := "GetDeleteState"
+func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*framework.Patch, error) {
+	o := "NewDeletePatch"
 
 	defer r.updateMetrics(o, time.Now())
 
-	v, err := r.resource.GetDeleteState(ctx, obj, currentState, desiredState)
+	v, err := r.resource.NewDeletePatch(ctx, obj, currentState, desiredState)
 	if err != nil {
 		r.updateErrorMetrics(o)
 		return nil, microerror.Mask(err)
 	}
 
 	return v, nil
-}
-
-func (r *Resource) GetUpdateState(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, interface{}, interface{}, error) {
-	o := "GetUpdateState"
-
-	defer r.updateMetrics(o, time.Now())
-
-	createState, deleteState, updateState, err := r.resource.GetUpdateState(ctx, obj, currentState, desiredState)
-	if err != nil {
-		r.updateErrorMetrics(o)
-		return nil, nil, nil, microerror.Mask(err)
-	}
-
-	return createState, deleteState, updateState, nil
 }
 
 func (r *Resource) Name() string {
 	return Name
 }
 
-func (r *Resource) ProcessCreateState(ctx context.Context, obj, createState interface{}) error {
-	o := "ProcessCreateState"
+func (r *Resource) ApplyCreatePatch(ctx context.Context, obj, createState interface{}) error {
+	o := "ApplyCreatePatch"
 
 	defer r.updateMetrics(o, time.Now())
 
-	err := r.resource.ProcessCreateState(ctx, obj, createState)
+	err := r.resource.ApplyCreatePatch(ctx, obj, createState)
 	if err != nil {
 		r.updateErrorMetrics(o)
 		return microerror.Mask(err)
@@ -158,12 +144,12 @@ func (r *Resource) ProcessCreateState(ctx context.Context, obj, createState inte
 	return nil
 }
 
-func (r *Resource) ProcessDeleteState(ctx context.Context, obj, deleteState interface{}) error {
-	o := "ProcessDeleteState"
+func (r *Resource) ApplyDeletePatch(ctx context.Context, obj, deleteState interface{}) error {
+	o := "ApplyDeletePatch"
 
 	defer r.updateMetrics(o, time.Now())
 
-	err := r.resource.ProcessDeleteState(ctx, obj, deleteState)
+	err := r.resource.ApplyDeletePatch(ctx, obj, deleteState)
 	if err != nil {
 		r.updateErrorMetrics(o)
 		return microerror.Mask(err)
@@ -172,12 +158,12 @@ func (r *Resource) ProcessDeleteState(ctx context.Context, obj, deleteState inte
 	return nil
 }
 
-func (r *Resource) ProcessUpdateState(ctx context.Context, obj, updateState interface{}) error {
-	o := "ProcessUpdateState"
+func (r *Resource) ApplyUpdatePatch(ctx context.Context, obj, updateState interface{}) error {
+	o := "ApplyUpdatePatch"
 
 	defer r.updateMetrics(o, time.Now())
 
-	err := r.resource.ProcessUpdateState(ctx, obj, updateState)
+	err := r.resource.ApplyUpdatePatch(ctx, obj, updateState)
 	if err != nil {
 		r.updateErrorMetrics(o)
 		return microerror.Mask(err)

--- a/framework/resource/metricsresource/resource_test.go
+++ b/framework/resource/metricsresource/resource_test.go
@@ -32,8 +32,10 @@ func Test_MetricsResource_ProcessCreate_ResourceOrder(t *testing.T) {
 	e := []string{
 		"GetCurrentState",
 		"GetDesiredState",
-		"GetCreateState",
-		"ProcessCreateState",
+		"NewUpdatePatch",
+		"ApplyCreatePatch",
+		"ApplyDeletePatch",
+		"ApplyUpdatePatch",
 	}
 	if !reflect.DeepEqual(e, tr.Order) {
 		t.Fatal("expected", e, "got", tr.Order)
@@ -64,8 +66,10 @@ func Test_MetricsResource_ProcessDelete_ResourceOrder(t *testing.T) {
 	e := []string{
 		"GetCurrentState",
 		"GetDesiredState",
-		"GetDeleteState",
-		"ProcessDeleteState",
+		"NewDeletePatch",
+		"ApplyCreatePatch",
+		"ApplyDeletePatch",
+		"ApplyUpdatePatch",
 	}
 	if !reflect.DeepEqual(e, tr.Order) {
 		t.Fatal("expected", e, "got", tr.Order)
@@ -96,10 +100,10 @@ func Test_MetricsResource_ProcessUpdate_ResourceOrder(t *testing.T) {
 	e := []string{
 		"GetCurrentState",
 		"GetDesiredState",
-		"GetUpdateState",
-		"ProcessCreateState",
-		"ProcessDeleteState",
-		"ProcessUpdateState",
+		"NewUpdatePatch",
+		"ApplyCreatePatch",
+		"ApplyDeletePatch",
+		"ApplyUpdatePatch",
 	}
 	if !reflect.DeepEqual(e, tr.Order) {
 		t.Fatal("expected", e, "got", tr.Order)
@@ -124,47 +128,48 @@ func (r *testResource) GetDesiredState(ctx context.Context, obj interface{}) (in
 	return nil, nil
 }
 
-func (r *testResource) GetCreateState(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
-	m := "GetCreateState"
+func (r *testResource) NewUpdatePatch(ctx context.Context, obj, cur, des interface{}) (*framework.Patch, error) {
+	m := "NewUpdatePatch"
 	r.Order = append(r.Order, m)
 
-	return nil, nil
+	p := framework.NewPatch()
+	p.SetCreate("test create data")
+	p.SetUpdate("test update data")
+	p.SetDelete("test delete data")
+	return p, nil
 }
 
-func (r *testResource) GetDeleteState(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
-	m := "GetDeleteState"
+func (r *testResource) NewDeletePatch(ctx context.Context, obj, cur, des interface{}) (*framework.Patch, error) {
+	m := "NewDeletePatch"
 	r.Order = append(r.Order, m)
 
-	return nil, nil
-}
-
-func (r *testResource) GetUpdateState(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, interface{}, interface{}, error) {
-	m := "GetUpdateState"
-	r.Order = append(r.Order, m)
-
-	return nil, nil, nil, nil
+	p := framework.NewPatch()
+	p.SetCreate("test create data")
+	p.SetUpdate("test update data")
+	p.SetDelete("test delete data")
+	return p, nil
 }
 
 func (r *testResource) Name() string {
 	return "testResource"
 }
 
-func (r *testResource) ProcessCreateState(ctx context.Context, obj, createState interface{}) error {
-	m := "ProcessCreateState"
+func (r *testResource) ApplyCreatePatch(ctx context.Context, obj, createState interface{}) error {
+	m := "ApplyCreatePatch"
 	r.Order = append(r.Order, m)
 
 	return nil
 }
 
-func (r *testResource) ProcessDeleteState(ctx context.Context, obj, deleteState interface{}) error {
-	m := "ProcessDeleteState"
+func (r *testResource) ApplyDeletePatch(ctx context.Context, obj, deleteState interface{}) error {
+	m := "ApplyDeletePatch"
 	r.Order = append(r.Order, m)
 
 	return nil
 }
 
-func (r *testResource) ProcessUpdateState(ctx context.Context, obj, updateState interface{}) error {
-	m := "ProcessUpdateState"
+func (r *testResource) ApplyUpdatePatch(ctx context.Context, obj, updateState interface{}) error {
+	m := "ApplyUpdatePatch"
 	r.Order = append(r.Order, m)
 
 	return nil

--- a/framework/resource/metricsresource/resource_test.go
+++ b/framework/resource/metricsresource/resource_test.go
@@ -133,9 +133,9 @@ func (r *testResource) NewUpdatePatch(ctx context.Context, obj, cur, des interfa
 	r.Order = append(r.Order, m)
 
 	p := framework.NewPatch()
-	p.SetCreate("test create data")
-	p.SetUpdate("test update data")
-	p.SetDelete("test delete data")
+	p.SetCreateChange("test create data")
+	p.SetUpdateChange("test update data")
+	p.SetDeleteChange("test delete data")
 	return p, nil
 }
 
@@ -144,9 +144,9 @@ func (r *testResource) NewDeletePatch(ctx context.Context, obj, cur, des interfa
 	r.Order = append(r.Order, m)
 
 	p := framework.NewPatch()
-	p.SetCreate("test create data")
-	p.SetUpdate("test update data")
-	p.SetDelete("test delete data")
+	p.SetCreateChange("test create data")
+	p.SetUpdateChange("test update data")
+	p.SetDeleteChange("test delete data")
 	return p, nil
 }
 
@@ -154,21 +154,21 @@ func (r *testResource) Name() string {
 	return "testResource"
 }
 
-func (r *testResource) ApplyCreatePatch(ctx context.Context, obj, createState interface{}) error {
+func (r *testResource) ApplyCreateChange(ctx context.Context, obj, createState interface{}) error {
 	m := "ApplyCreatePatch"
 	r.Order = append(r.Order, m)
 
 	return nil
 }
 
-func (r *testResource) ApplyDeletePatch(ctx context.Context, obj, deleteState interface{}) error {
+func (r *testResource) ApplyDeleteChange(ctx context.Context, obj, deleteState interface{}) error {
 	m := "ApplyDeletePatch"
 	r.Order = append(r.Order, m)
 
 	return nil
 }
 
-func (r *testResource) ApplyUpdatePatch(ctx context.Context, obj, updateState interface{}) error {
+func (r *testResource) ApplyUpdateChange(ctx context.Context, obj, updateState interface{}) error {
 	m := "ApplyUpdatePatch"
 	r.Order = append(r.Order, m)
 

--- a/framework/resource/retryresource/resource.go
+++ b/framework/resource/retryresource/resource.go
@@ -129,12 +129,12 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 	return v, nil
 }
 
-func (r *Resource) GetCreateState(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*framework.Patch, error) {
 	var err error
 
-	var v interface{}
+	var v *framework.Patch
 	o := func() error {
-		v, err = r.resource.GetCreateState(ctx, obj, currentState, desiredState)
+		v, err = r.resource.NewUpdatePatch(ctx, obj, currentState, desiredState)
 		if err != nil {
 			return microerror.Mask(err)
 		}
@@ -143,7 +143,7 @@ func (r *Resource) GetCreateState(ctx context.Context, obj, currentState, desire
 	}
 
 	n := func(err error, dur time.Duration) {
-		r.logger.Log("warning", fmt.Sprintf("retrying 'GetCreateState' due to error (%s)", err.Error()))
+		r.logger.Log("warning", fmt.Sprintf("retrying 'NewUpdatePatch' due to error (%s)", err.Error()))
 	}
 
 	err = backoff.RetryNotify(o, r.backOff, n)
@@ -154,12 +154,12 @@ func (r *Resource) GetCreateState(ctx context.Context, obj, currentState, desire
 	return v, nil
 }
 
-func (r *Resource) GetDeleteState(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*framework.Patch, error) {
 	var err error
 
-	var v interface{}
+	var v *framework.Patch
 	o := func() error {
-		v, err = r.resource.GetDeleteState(ctx, obj, currentState, desiredState)
+		v, err = r.resource.NewDeletePatch(ctx, obj, currentState, desiredState)
 		if err != nil {
 			return microerror.Mask(err)
 		}
@@ -168,7 +168,7 @@ func (r *Resource) GetDeleteState(ctx context.Context, obj, currentState, desire
 	}
 
 	n := func(err error, dur time.Duration) {
-		r.logger.Log("warning", fmt.Sprintf("retrying 'GetDeleteState' due to error (%s)", err.Error()))
+		r.logger.Log("warning", fmt.Sprintf("retrying 'NewDeletePatch' due to error (%s)", err.Error()))
 	}
 
 	err = backoff.RetryNotify(o, r.backOff, n)
@@ -177,43 +177,15 @@ func (r *Resource) GetDeleteState(ctx context.Context, obj, currentState, desire
 	}
 
 	return v, nil
-}
-
-func (r *Resource) GetUpdateState(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, interface{}, interface{}, error) {
-	var err error
-
-	var createState interface{}
-	var deleteState interface{}
-	var updateState interface{}
-
-	o := func() error {
-		createState, deleteState, updateState, err = r.resource.GetUpdateState(ctx, obj, currentState, desiredState)
-		if err != nil {
-			return microerror.Mask(err)
-		}
-
-		return nil
-	}
-
-	n := func(err error, dur time.Duration) {
-		r.logger.Log("warning", fmt.Sprintf("retrying 'GetUpdateState' due to error (%s)", err.Error()))
-	}
-
-	err = backoff.RetryNotify(o, r.backOff, n)
-	if err != nil {
-		return nil, nil, nil, microerror.Mask(err)
-	}
-
-	return createState, deleteState, updateState, nil
 }
 
 func (r *Resource) Name() string {
 	return Name
 }
 
-func (r *Resource) ProcessCreateState(ctx context.Context, obj, createState interface{}) error {
+func (r *Resource) ApplyCreatePatch(ctx context.Context, obj, createState interface{}) error {
 	o := func() error {
-		err := r.resource.ProcessCreateState(ctx, obj, createState)
+		err := r.resource.ApplyCreatePatch(ctx, obj, createState)
 		if err != nil {
 			return microerror.Mask(err)
 		}
@@ -222,7 +194,7 @@ func (r *Resource) ProcessCreateState(ctx context.Context, obj, createState inte
 	}
 
 	n := func(err error, dur time.Duration) {
-		r.logger.Log("warning", fmt.Sprintf("retrying 'ProcessCreateState' due to error (%s)", err.Error()))
+		r.logger.Log("warning", fmt.Sprintf("retrying 'ApplyCreatePatch' due to error (%s)", err.Error()))
 	}
 
 	err := backoff.RetryNotify(o, r.backOff, n)
@@ -233,9 +205,9 @@ func (r *Resource) ProcessCreateState(ctx context.Context, obj, createState inte
 	return nil
 }
 
-func (r *Resource) ProcessDeleteState(ctx context.Context, obj, deleteState interface{}) error {
+func (r *Resource) ApplyDeletePatch(ctx context.Context, obj, deleteState interface{}) error {
 	o := func() error {
-		err := r.resource.ProcessDeleteState(ctx, obj, deleteState)
+		err := r.resource.ApplyDeletePatch(ctx, obj, deleteState)
 		if err != nil {
 			return microerror.Mask(err)
 		}
@@ -244,7 +216,7 @@ func (r *Resource) ProcessDeleteState(ctx context.Context, obj, deleteState inte
 	}
 
 	n := func(err error, dur time.Duration) {
-		r.logger.Log("warning", fmt.Sprintf("retrying 'ProcessDeleteState' due to error (%s)", err.Error()))
+		r.logger.Log("warning", fmt.Sprintf("retrying 'ApplyDeletePatch' due to error (%s)", err.Error()))
 	}
 
 	err := backoff.RetryNotify(o, r.backOff, n)
@@ -255,9 +227,9 @@ func (r *Resource) ProcessDeleteState(ctx context.Context, obj, deleteState inte
 	return nil
 }
 
-func (r *Resource) ProcessUpdateState(ctx context.Context, obj, updateState interface{}) error {
+func (r *Resource) ApplyUpdatePatch(ctx context.Context, obj, updateState interface{}) error {
 	o := func() error {
-		err := r.resource.ProcessUpdateState(ctx, obj, updateState)
+		err := r.resource.ApplyUpdatePatch(ctx, obj, updateState)
 		if err != nil {
 			return microerror.Mask(err)
 		}
@@ -266,7 +238,7 @@ func (r *Resource) ProcessUpdateState(ctx context.Context, obj, updateState inte
 	}
 
 	n := func(err error, dur time.Duration) {
-		r.logger.Log("warning", fmt.Sprintf("retrying 'ProcessUpdateState' due to error (%s)", err.Error()))
+		r.logger.Log("warning", fmt.Sprintf("retrying 'ApplyUpdatePatch' due to error (%s)", err.Error()))
 	}
 
 	err := backoff.RetryNotify(o, r.backOff, n)

--- a/framework/resource/retryresource/resource.go
+++ b/framework/resource/retryresource/resource.go
@@ -183,9 +183,9 @@ func (r *Resource) Name() string {
 	return Name
 }
 
-func (r *Resource) ApplyCreatePatch(ctx context.Context, obj, createState interface{}) error {
+func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createState interface{}) error {
 	o := func() error {
-		err := r.resource.ApplyCreatePatch(ctx, obj, createState)
+		err := r.resource.ApplyCreateChange(ctx, obj, createState)
 		if err != nil {
 			return microerror.Mask(err)
 		}
@@ -205,9 +205,9 @@ func (r *Resource) ApplyCreatePatch(ctx context.Context, obj, createState interf
 	return nil
 }
 
-func (r *Resource) ApplyDeletePatch(ctx context.Context, obj, deleteState interface{}) error {
+func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteState interface{}) error {
 	o := func() error {
-		err := r.resource.ApplyDeletePatch(ctx, obj, deleteState)
+		err := r.resource.ApplyDeleteChange(ctx, obj, deleteState)
 		if err != nil {
 			return microerror.Mask(err)
 		}
@@ -227,9 +227,9 @@ func (r *Resource) ApplyDeletePatch(ctx context.Context, obj, deleteState interf
 	return nil
 }
 
-func (r *Resource) ApplyUpdatePatch(ctx context.Context, obj, updateState interface{}) error {
+func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateState interface{}) error {
 	o := func() error {
-		err := r.resource.ApplyUpdatePatch(ctx, obj, updateState)
+		err := r.resource.ApplyUpdateChange(ctx, obj, updateState)
 		if err != nil {
 			return microerror.Mask(err)
 		}

--- a/framework/resource/retryresource/resource_test.go
+++ b/framework/resource/retryresource/resource_test.go
@@ -26,8 +26,10 @@ func Test_RetryResource_ProcessCreate_ResourceOrder_RetryOnError(t *testing.T) {
 				"GetCurrentState",
 				"GetCurrentState",
 				"GetDesiredState",
-				"GetCreateState",
-				"ProcessCreateState",
+				"NewUpdatePatch",
+				"ApplyCreatePatch",
+				"ApplyDeletePatch",
+				"ApplyUpdatePatch",
 			},
 		},
 		{
@@ -38,20 +40,24 @@ func Test_RetryResource_ProcessCreate_ResourceOrder_RetryOnError(t *testing.T) {
 				"GetCurrentState",
 				"GetCurrentState",
 				"GetDesiredState",
-				"GetCreateState",
-				"ProcessCreateState",
+				"NewUpdatePatch",
+				"ApplyCreatePatch",
+				"ApplyDeletePatch",
+				"ApplyUpdatePatch",
 			},
 		},
 		{
 			ErrorCount:  2,
-			ErrorMethod: "ProcessCreateState",
+			ErrorMethod: "ApplyCreatePatch",
 			ExpectedMethodOrder: []string{
 				"GetCurrentState",
 				"GetDesiredState",
-				"GetCreateState",
-				"ProcessCreateState",
-				"ProcessCreateState",
-				"ProcessCreateState",
+				"NewUpdatePatch",
+				"ApplyCreatePatch",
+				"ApplyCreatePatch",
+				"ApplyCreatePatch",
+				"ApplyDeletePatch",
+				"ApplyUpdatePatch",
 			},
 		},
 	}
@@ -114,8 +120,10 @@ func Test_RetryResource_ProcessCreate_ResourceOrder(t *testing.T) {
 	e := []string{
 		"GetCurrentState",
 		"GetDesiredState",
-		"GetCreateState",
-		"ProcessCreateState",
+		"NewUpdatePatch",
+		"ApplyCreatePatch",
+		"ApplyDeletePatch",
+		"ApplyUpdatePatch",
 	}
 	if !reflect.DeepEqual(e, tr.Order) {
 		t.Fatal("expected", e, "got", tr.Order)
@@ -138,8 +146,10 @@ func Test_RetryResource_ProcessDelete_ResourceOrder_RetryOnError(t *testing.T) {
 				"GetCurrentState",
 				"GetCurrentState",
 				"GetDesiredState",
-				"GetDeleteState",
-				"ProcessDeleteState",
+				"NewDeletePatch",
+				"ApplyCreatePatch",
+				"ApplyDeletePatch",
+				"ApplyUpdatePatch",
 			},
 		},
 		{
@@ -150,20 +160,24 @@ func Test_RetryResource_ProcessDelete_ResourceOrder_RetryOnError(t *testing.T) {
 				"GetCurrentState",
 				"GetCurrentState",
 				"GetDesiredState",
-				"GetDeleteState",
-				"ProcessDeleteState",
+				"NewDeletePatch",
+				"ApplyCreatePatch",
+				"ApplyDeletePatch",
+				"ApplyUpdatePatch",
 			},
 		},
 		{
 			ErrorCount:  2,
-			ErrorMethod: "ProcessDeleteState",
+			ErrorMethod: "ApplyDeletePatch",
 			ExpectedMethodOrder: []string{
 				"GetCurrentState",
 				"GetDesiredState",
-				"GetDeleteState",
-				"ProcessDeleteState",
-				"ProcessDeleteState",
-				"ProcessDeleteState",
+				"NewDeletePatch",
+				"ApplyCreatePatch",
+				"ApplyDeletePatch",
+				"ApplyDeletePatch",
+				"ApplyDeletePatch",
+				"ApplyUpdatePatch",
 			},
 		},
 	}
@@ -226,8 +240,10 @@ func Test_RetryResource_ProcessDelete_ResourceOrder(t *testing.T) {
 	e := []string{
 		"GetCurrentState",
 		"GetDesiredState",
-		"GetDeleteState",
-		"ProcessDeleteState",
+		"NewDeletePatch",
+		"ApplyCreatePatch",
+		"ApplyDeletePatch",
+		"ApplyUpdatePatch",
 	}
 	if !reflect.DeepEqual(e, tr.Order) {
 		t.Fatal("expected", e, "got", tr.Order)
@@ -250,10 +266,10 @@ func Test_RetryResource_ProcessUpdate_ResourceOrder_RetryOnError(t *testing.T) {
 				"GetCurrentState",
 				"GetCurrentState",
 				"GetDesiredState",
-				"GetUpdateState",
-				"ProcessCreateState",
-				"ProcessDeleteState",
-				"ProcessUpdateState",
+				"NewUpdatePatch",
+				"ApplyCreatePatch",
+				"ApplyDeletePatch",
+				"ApplyUpdatePatch",
 			},
 		},
 		{
@@ -264,24 +280,24 @@ func Test_RetryResource_ProcessUpdate_ResourceOrder_RetryOnError(t *testing.T) {
 				"GetCurrentState",
 				"GetCurrentState",
 				"GetDesiredState",
-				"GetUpdateState",
-				"ProcessCreateState",
-				"ProcessDeleteState",
-				"ProcessUpdateState",
+				"NewUpdatePatch",
+				"ApplyCreatePatch",
+				"ApplyDeletePatch",
+				"ApplyUpdatePatch",
 			},
 		},
 		{
 			ErrorCount:  2,
-			ErrorMethod: "ProcessUpdateState",
+			ErrorMethod: "ApplyUpdatePatch",
 			ExpectedMethodOrder: []string{
 				"GetCurrentState",
 				"GetDesiredState",
-				"GetUpdateState",
-				"ProcessCreateState",
-				"ProcessDeleteState",
-				"ProcessUpdateState",
-				"ProcessUpdateState",
-				"ProcessUpdateState",
+				"NewUpdatePatch",
+				"ApplyCreatePatch",
+				"ApplyDeletePatch",
+				"ApplyUpdatePatch",
+				"ApplyUpdatePatch",
+				"ApplyUpdatePatch",
 			},
 		},
 	}
@@ -344,10 +360,10 @@ func Test_RetryResource_ProcessUpdate_ResourceOrder(t *testing.T) {
 	e := []string{
 		"GetCurrentState",
 		"GetDesiredState",
-		"GetUpdateState",
-		"ProcessCreateState",
-		"ProcessDeleteState",
-		"ProcessUpdateState",
+		"NewUpdatePatch",
+		"ApplyCreatePatch",
+		"ApplyDeletePatch",
+		"ApplyUpdatePatch",
 	}
 	if !reflect.DeepEqual(e, tr.Order) {
 		t.Fatal("expected", e, "got", tr.Order)
@@ -385,45 +401,34 @@ func (r *testResource) GetDesiredState(ctx context.Context, obj interface{}) (in
 	return nil, nil
 }
 
-func (r *testResource) GetCreateState(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
-	m := "GetCreateState"
+func (r *testResource) NewUpdatePatch(ctx context.Context, obj, cur, des interface{}) (*framework.Patch, error) {
+	m := "NewUpdatePatch"
 	r.Order = append(r.Order, m)
 
-	if r.returnErrorFor(m) {
-		return nil, r.Error
-	}
-
-	return nil, nil
+	p := framework.NewPatch()
+	p.SetCreate("test create data")
+	p.SetUpdate("test update data")
+	p.SetDelete("test delete data")
+	return p, nil
 }
 
-func (r *testResource) GetDeleteState(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
-	m := "GetDeleteState"
+func (r *testResource) NewDeletePatch(ctx context.Context, obj, cur, des interface{}) (*framework.Patch, error) {
+	m := "NewDeletePatch"
 	r.Order = append(r.Order, m)
 
-	if r.returnErrorFor(m) {
-		return nil, r.Error
-	}
-
-	return nil, nil
-}
-
-func (r *testResource) GetUpdateState(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, interface{}, interface{}, error) {
-	m := "GetUpdateState"
-	r.Order = append(r.Order, m)
-
-	if r.returnErrorFor(m) {
-		return nil, nil, nil, r.Error
-	}
-
-	return nil, nil, nil, nil
+	p := framework.NewPatch()
+	p.SetCreate("test create data")
+	p.SetUpdate("test update data")
+	p.SetDelete("test delete data")
+	return p, nil
 }
 
 func (r *testResource) Name() string {
 	return "testResource"
 }
 
-func (r *testResource) ProcessCreateState(ctx context.Context, obj, createState interface{}) error {
-	m := "ProcessCreateState"
+func (r *testResource) ApplyCreatePatch(ctx context.Context, obj, createState interface{}) error {
+	m := "ApplyCreatePatch"
 	r.Order = append(r.Order, m)
 
 	if r.returnErrorFor(m) {
@@ -433,8 +438,8 @@ func (r *testResource) ProcessCreateState(ctx context.Context, obj, createState 
 	return nil
 }
 
-func (r *testResource) ProcessDeleteState(ctx context.Context, obj, deleteState interface{}) error {
-	m := "ProcessDeleteState"
+func (r *testResource) ApplyDeletePatch(ctx context.Context, obj, deleteState interface{}) error {
+	m := "ApplyDeletePatch"
 	r.Order = append(r.Order, m)
 
 	if r.returnErrorFor(m) {
@@ -444,8 +449,8 @@ func (r *testResource) ProcessDeleteState(ctx context.Context, obj, deleteState 
 	return nil
 }
 
-func (r *testResource) ProcessUpdateState(ctx context.Context, obj, updateState interface{}) error {
-	m := "ProcessUpdateState"
+func (r *testResource) ApplyUpdatePatch(ctx context.Context, obj, updateState interface{}) error {
+	m := "ApplyUpdatePatch"
 	r.Order = append(r.Order, m)
 
 	if r.returnErrorFor(m) {

--- a/framework/resource/retryresource/resource_test.go
+++ b/framework/resource/retryresource/resource_test.go
@@ -406,9 +406,9 @@ func (r *testResource) NewUpdatePatch(ctx context.Context, obj, cur, des interfa
 	r.Order = append(r.Order, m)
 
 	p := framework.NewPatch()
-	p.SetCreate("test create data")
-	p.SetUpdate("test update data")
-	p.SetDelete("test delete data")
+	p.SetCreateChange("test create data")
+	p.SetUpdateChange("test update data")
+	p.SetDeleteChange("test delete data")
 	return p, nil
 }
 
@@ -417,9 +417,9 @@ func (r *testResource) NewDeletePatch(ctx context.Context, obj, cur, des interfa
 	r.Order = append(r.Order, m)
 
 	p := framework.NewPatch()
-	p.SetCreate("test create data")
-	p.SetUpdate("test update data")
-	p.SetDelete("test delete data")
+	p.SetCreateChange("test create data")
+	p.SetUpdateChange("test update data")
+	p.SetDeleteChange("test delete data")
 	return p, nil
 }
 
@@ -427,7 +427,7 @@ func (r *testResource) Name() string {
 	return "testResource"
 }
 
-func (r *testResource) ApplyCreatePatch(ctx context.Context, obj, createState interface{}) error {
+func (r *testResource) ApplyCreateChange(ctx context.Context, obj, createState interface{}) error {
 	m := "ApplyCreatePatch"
 	r.Order = append(r.Order, m)
 
@@ -438,7 +438,7 @@ func (r *testResource) ApplyCreatePatch(ctx context.Context, obj, createState in
 	return nil
 }
 
-func (r *testResource) ApplyDeletePatch(ctx context.Context, obj, deleteState interface{}) error {
+func (r *testResource) ApplyDeleteChange(ctx context.Context, obj, deleteState interface{}) error {
 	m := "ApplyDeletePatch"
 	r.Order = append(r.Order, m)
 
@@ -449,7 +449,7 @@ func (r *testResource) ApplyDeletePatch(ctx context.Context, obj, deleteState in
 	return nil
 }
 
-func (r *testResource) ApplyUpdatePatch(ctx context.Context, obj, updateState interface{}) error {
+func (r *testResource) ApplyUpdateChange(ctx context.Context, obj, updateState interface{}) error {
 	m := "ApplyUpdatePatch"
 	r.Order = append(r.Order, m)
 

--- a/framework/spec.go
+++ b/framework/spec.go
@@ -2,47 +2,6 @@ package framework
 
 import "context"
 
-type patchType string
-
-const (
-	patchCreate patchType = "create"
-	patchDelete patchType = "delete"
-	patchUpdate patchType = "update"
-)
-
-// Patch is a set of information required in order to reconcile to the desired
-// state. Patch is split into three parts: create, delete and update. The parts
-// are passed as arguments to Resource's Create, Delete and Update functions
-// respectively. Patch is guaranteed to be applied in that order (i.e. create,
-// update, delete).
-type Patch struct {
-	data map[patchType]interface{}
-}
-
-func NewPatch() *Patch {
-	return &Patch{
-		data: make(map[patchType]interface{}, 3),
-	}
-}
-
-func (p *Patch) getCreate() (interface{}, bool) {
-	create, ok := p.data[patchCreate]
-	return create, ok
-}
-
-func (p *Patch) getDelete() (interface{}, bool) {
-	delete, ok := p.data[patchDelete]
-	return delete, ok
-}
-func (p *Patch) getUpdate() (interface{}, bool) {
-	update, ok := p.data[patchUpdate]
-	return update, ok
-}
-
-func (p *Patch) SetCreate(create interface{}) { p.data[patchCreate] = create }
-func (p *Patch) SetDelete(delete interface{}) { p.data[patchDelete] = delete }
-func (p *Patch) SetUpdate(update interface{}) { p.data[patchUpdate] = update }
-
 // Resource implements the building blocks of any resource business logic being
 // reconciled when observing custom resources. This interface provides
 // a guideline for an easier way to follow the rather complex intentions of

--- a/framework/spec.go
+++ b/framework/spec.go
@@ -75,19 +75,19 @@ type Resource interface {
 	// ApplyCreateChange only has to create resources based on its provided
 	// input. All other reconciliation logic and state transformation is
 	// already done at this point of the reconciliation loop.
-	ApplyCreateChange(ctx context.Context, obj, createPatch interface{}) error
+	ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error
 	// ApplyDeleteChange receives the new custom object observed during
 	// custom resource watches. It also receives the delete portion of the
 	// Patch provided by NewUpdatePatch or NewDeletePatch.
 	// ApplyDeleteChange only has to delete resources based on its provided
 	// input. All other reconciliation logic and state transformation is
 	// already done at this point of the reconciliation loop.
-	ApplyDeleteChange(ctx context.Context, obj, deletePatch interface{}) error
+	ApplyDeleteChange(ctx context.Context, obj, deleteChange interface{}) error
 	// ApplyUpdateChange receives the new custom object observed during
 	// custom resource watches. It also receives the update portion of the
 	// Patch provided by NewUpdatePatch or NewDeletePatch.
 	// ApplyUpdateChange has to update resources based on its provided
 	// input. All other reconciliation logic and state transformation is
 	// already done at this point of the reconciliation loop.
-	ApplyUpdateChange(ctx context.Context, obj, updatePatch interface{}) error
+	ApplyUpdateChange(ctx context.Context, obj, updateChange interface{}) error
 }

--- a/framework/spec.go
+++ b/framework/spec.go
@@ -55,8 +55,8 @@ type Resource interface {
 	// GetCurrentState and the desired state as provided by
 	// GetDesiredState. NewUpdatePatch analyses the current and desired
 	// state and returns the patch to be applied by Create, Delete, and
-	// Update functions. ApplyCreatePatch, ApplyDeletePatch, and
-	// ApplyUpdatePatch are called only when the corresponding patch part
+	// Update functions. ApplyCreateChange, ApplyDeleteChange, and
+	// ApplyUpdateChange are called only when the corresponding patch part
 	// was created.
 	NewUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*Patch, error)
 	// NewDeletePatch is called upon observed custom object deletion. It
@@ -64,30 +64,30 @@ type Resource interface {
 	// GetCurrentState and the desired state as provided by
 	// GetDesiredState. NewDeletePatch analyses the current and desired
 	// state returns the patch to be applied by Create, Delete, and Update
-	// functions. ApplyCreatePatch, ApplyDeletePatch, and
-	// ApplyUpdatePatch are called only when the corresponding patch part
+	// functions. ApplyCreateChange, ApplyDeleteChange, and
+	// ApplyUpdateChange are called only when the corresponding patch part
 	// was created.
 	NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*Patch, error)
 
-	// ApplyCreatePatch receives the new custom object observed during
-	// custom resource watches. It also receives the ApplyCreatePatch
-	// portion of the Patch provided by NewUpdatePatch or NewDeletePatch.
-	// ApplyCreatePatch only has to create resources based on its provided
+	// ApplyCreateChange receives the new custom object observed during
+	// custom resource watches. It also receives the create portion of the
+	// Patch provided by NewUpdatePatch or NewDeletePatch.
+	// ApplyCreateChange only has to create resources based on its provided
 	// input. All other reconciliation logic and state transformation is
 	// already done at this point of the reconciliation loop.
-	ApplyCreatePatch(ctx context.Context, obj, createPatch interface{}) error
-	// ApplyDeletePatch receives the new custom object observed during
-	// custom resource watches. It also receives the ApplyDeletePatch
-	// portion of the Patch provided by NewUpdatePatch or NewDeletePatch.
-	// ApplyDeletePatch only has to delete resources based on its provided
+	ApplyCreateChange(ctx context.Context, obj, createPatch interface{}) error
+	// ApplyDeleteChange receives the new custom object observed during
+	// custom resource watches. It also receives the delete portion of the
+	// Patch provided by NewUpdatePatch or NewDeletePatch.
+	// ApplyDeleteChange only has to delete resources based on its provided
 	// input. All other reconciliation logic and state transformation is
 	// already done at this point of the reconciliation loop.
-	ApplyDeletePatch(ctx context.Context, obj, deletePatch interface{}) error
-	// ApplyUpdatePatch receives the new custom object observed during
-	// custom resource watches. It also receives the state intended to be
-	// updated as provided by NewUpdatePatch or NewDeletePatch.
-	// ApplyUpdatePatch has to update resources based on its provided
+	ApplyDeleteChange(ctx context.Context, obj, deletePatch interface{}) error
+	// ApplyUpdateChange receives the new custom object observed during
+	// custom resource watches. It also receives the update portion of the
+	// Patch provided by NewUpdatePatch or NewDeletePatch.
+	// ApplyUpdateChange has to update resources based on its provided
 	// input. All other reconciliation logic and state transformation is
 	// already done at this point of the reconciliation loop.
-	ApplyUpdatePatch(ctx context.Context, obj, updatePatch interface{}) error
+	ApplyUpdateChange(ctx context.Context, obj, updatePatch interface{}) error
 }

--- a/framework/spec.go
+++ b/framework/spec.go
@@ -2,10 +2,62 @@ package framework
 
 import "context"
 
+type patchType string
+
+const (
+	patchCreate = "create"
+	patchDelete = "delete"
+	patchUpdate = "update"
+)
+
+// Patch is a set of information required in order to reconcile to the desired
+// state. Patch is split to three parts: create, delete and update. The parts
+// are passed as arguments to Resource's Create, Delete and Update functions
+// respectively. Patch is guaranteed to be applied in that order (i.e. create,
+// update, delete).
+type Patch struct {
+	data map[patchType]interface{}
+}
+
+func NewPatch() *Patch {
+	return &Patch{
+		data: make(map[patchType]interface{}, 3),
+	}
+}
+
+func (p *Patch) getCreate() (interface{}, bool) {
+	create, ok := p.data[patchCreate]
+	return create, ok
+}
+
+func (p *Patch) getDelete() (interface{}, bool) {
+	delete, ok := p.data[patchDelete]
+	return delete, ok
+}
+func (p *Patch) getUpdate() (interface{}, bool) {
+	update, ok := p.data[patchUpdate]
+	return update, ok
+}
+
+func (p *Patch) SetCreate(create interface{}) { p.data[patchCreate] = create }
+func (p *Patch) SetDelete(delete interface{}) { p.data[patchDelete] = delete }
+func (p *Patch) SetUpdate(update interface{}) { p.data[patchUpdate] = update }
+
 // Resource implements the building blocks of any resource business logic being
 // reconciled when observing TPRs. This interface provides a guideline for an
 // easier way to follow the rather complex intentions of operators in general.
 type Resource interface {
+	// Name returns the resource's name used for identification.
+	Name() string
+	// Underlying returns the underlying resource which is wrapped by the calling
+	// resource. Underlying must always return a non nil resource. Otherwise
+	// proper resource chaining and execution cannot be guaranteed. In case a
+	// resource does not wrap any other resource, Underlying must return the
+	// resource that does not wrap any resource. The returned resource is then the
+	// origin, the underlying resource of the chain. In combination with Name,
+	// Underlying can be used for proper identification.
+	Underlying() Resource
+
 	// GetCurrentState receives the custom object observed during TPR watches. Its
 	// purpose is to return the current state of the resources being managed by
 	// the operator. This can e.g. be some actual data within a configmap as
@@ -29,81 +81,49 @@ type Resource interface {
 	// and return information about Flannel bridges, how they should look like on
 	// a server host.
 	//
-	// NOTE GetDesiredState is called on create, delete and update events. When
-	// called on create and delete events the provided custom object will be the
+	// NOTE GetDesiredState is called on create and update events. When
+	// called on create events the provided custom object will be the
 	// custom object currently known to the informer. On update events the
-	// informer knows about the old and the new custom object. GetDesiredState
-	// then receives the new custom object to be able to compute the desired state
-	// of a system.
+	// informer knows about the old and the new custom object.
+	// GetDesiredState then receives the new custom object to be able to
+	// compute the desired state of a system.
 	GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error)
-	// GetCreateState receives the custom object observed during TPR watches. It
-	// also receives the current state as provided by GetCurrentState and the
-	// desired state as provided by GetDesiredState. GetCreateState analyses the
-	// current and desired state and returns the state intended to be created by
-	// ProcessCreateState.
-	GetCreateState(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error)
-	// GetDeleteState receives the custom object observed during TPR watches. It
-	// also receives the current state as provided by GetCurrentState and the
-	// desired state as provided by GetDesiredState. GetDeleteState analyses the
-	// current and desired state and returns the state intended to be deleted by
-	// ProcessDeleteState.
-	GetDeleteState(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error)
-	// GetUpdateState receives the new custom object observed during TPR watches.
-	// It also receives the current state as provided by GetCurrentState and the
-	// desired state as provided by GetDesiredState. GetUpdateState analyses the
-	// current and desired state and returns the states intended to be created,
-	// deleted and updated. The returned create state will be given to
-	// ProcessCreateState. The returned delete state will be given to
-	// ProcessDeleteState. The returned update state will be given to
-	// ProcessUpdateState.
-	//
-	// NOTE simple resources not concerned with being updated do not have to
-	// implement anything but just fulfil the resource interface. More complex
-	// resources, e.g. those managing multiple entities of themselves at once may
-	// require a more complex update mechanism. Then multiple entities might be
-	// added, removed and/or modified over the course of the resource's lifecycle.
-	// This transformation has to be reflected by different states which are
-	// returned by GetUpdateState. The first value being returned is the create
-	// state, the second the delete state and the third the update state.
-	GetUpdateState(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, interface{}, interface{}, error)
-	// Name returns the resource's name used for identification.
-	Name() string
-	// ProcessCreateState receives the new custom object observed during TPR
-	// watches. It also receives the state intended to be created as provided by
-	// GetCreateState. ProcessCreateState only has to create resources based on
-	// its provided input. All other reconciliation logic and state transformation
-	// is already done at this point of the reconciliation loop.
-	//
-	// NOTE ProcessCreateState is called on create and update events. When called
-	// on create events the provided custom object will be the custom object
-	// currently known to the informer. On update events the informer knows about
-	// the old and the new custom object. ProcessCreateState then receives the new
-	// custom object to be able to process the create state of a system.
-	ProcessCreateState(ctx context.Context, obj, createState interface{}) error
-	// ProcessDeleteState receives the new custom object observed during TPR
-	// watches. It also receives the state intended to be deleted as provided by
-	// GetDeleteState. ProcessDeleteState only has to delete resources based on
-	// its provided input. All other reconciliation logic and state transformation
-	// is already done at this point of the reconciliation loop.
-	//
-	// NOTE ProcessDeleteState is called on delete and update events. When called
-	// on delete events the provided custom object will be the custom object
-	// currently known to the informer. On update events the informer knows about
-	// the old and the new custom object. ProcessDeleteState then receives the new
-	// custom object to be able to process the delete state of a system.
-	ProcessDeleteState(ctx context.Context, obj, deleteState interface{}) error
-	// ProcessUpdateState receives the new custom object observed during TPR
-	// watches. It also receives the state intended to be updated as provided by
-	// GetUpdateState. ProcessUpdateState has to update resources based on its
-	// provided input. All other reconciliation logic and state transformation is
-	// already done at this point of the reconciliation loop.
-	ProcessUpdateState(ctx context.Context, obj, updateState interface{}) error
-	// Underlying returns the underlying resource which is wrapped by the calling
-	// resource. Underlying must always return a non nil resource. Otherwise
-	// proper resource chaining and execution cannot be guaranteed. In case a
-	// resource does not wrap any other resource, Underlying must return the
-	// resource that does not wrap any resource. The returned resource is then the
-	// origin, the underlying resource of the chain. In combination with Name,
-	// Underlying can be used for proper identification.
-	Underlying() Resource
+
+	// NewUpdatePatch is callend upon observed CRO/TPO change. It receives the
+	// observed custom object, the current state as provided by GetCurrentState and
+	// the desired state as provided by GetDesiredState. NewUpdatePatch analyses
+	// the current and desired state and returns the patch state to be
+	// applied by Create, Delete, and Update functions. Create, Delete, and
+	// Update are called only when the corresponding patch state was
+	// created.
+	NewUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*Patch, error)
+	// NewDeletePatch is called upon observed CRO/TPO deleteion. It
+	// receives the deleted custom object, the current state as provided by
+	// GetCurrentState. NewDeletePatch analyses the current state
+	// returns the patch state to be applied by Create, Delete, and Update
+	// functions. Create, Delete, and Update are called only when the
+	// corresponding patch state was created.
+	NewDeletePatch(ctx context.Context, obj, currentState interface{}) (*Patch, error)
+
+	// Create receives the new custom object observed during TPR watches.
+	// It also receives the Create portion of the Patch provided by
+	// NewUpdatePatch or NewDeletePatch. Create only has to create
+	// resources based on its provided input. All other reconciliation
+	// logic and state transformation is already done at this point of the
+	// reconciliation loop.
+	Create(ctx context.Context, obj, createPatch interface{}) error
+	// Delete receives the new custom object observed during TPR watches.
+	// It also receives the Delete portion of the Patch provided by
+	// NewUpdatePatch or NewDeletePatch. Delete only has to delete
+	// resources based on its provided input. All other reconciliation
+	// logic and state transformation is already done at this point of the
+	// reconciliation loop.
+	Delete(ctx context.Context, obj, deletePatch interface{}) error
+	// Update receives the new custom object observed during TPR watches.
+	// It also receives the state intended to be updated as provided by
+	// NewUpdatePatch or NewDeletePatch. Update has to update resources
+	// based on its provided input. All other reconciliation logic and
+	// state transformation is already done at this point of the
+	// reconciliation loop.
+	Update(ctx context.Context, obj, updatePatch interface{}) error
 }

--- a/framework/spec.go
+++ b/framework/spec.go
@@ -81,49 +81,52 @@ type Resource interface {
 	// and return information about Flannel bridges, how they should look like on
 	// a server host.
 	//
-	// NOTE GetDesiredState is called on create and update events. When
-	// called on create events the provided custom object will be the
+	// NOTE GetDesiredState is called on create, delete and update events.
+	// When called on create events the provided custom object will be the
 	// custom object currently known to the informer. On update events the
 	// informer knows about the old and the new custom object.
 	// GetDesiredState then receives the new custom object to be able to
 	// compute the desired state of a system.
 	GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error)
 
-	// NewUpdatePatch is callend upon observed CRO/TPO change. It receives the
-	// observed custom object, the current state as provided by GetCurrentState and
-	// the desired state as provided by GetDesiredState. NewUpdatePatch analyses
-	// the current and desired state and returns the patch state to be
-	// applied by Create, Delete, and Update functions. Create, Delete, and
-	// Update are called only when the corresponding patch state was
-	// created.
+	// NewUpdatePatch is callend upon observed CRO/TPO change. It receives
+	// the observed custom object, the current state as provided by
+	// GetCurrentState and the desired state as provided by
+	// GetDesiredState. NewUpdatePatch analyses the current and desired
+	// state and returns the patch to be applied by Create, Delete, and
+	// Update functions. ApplyCreatePatch, ApplyDeletePatch, and
+	// ApplyUpdatePatch are called only when the corresponding patch part
+	// was created.
 	NewUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*Patch, error)
 	// NewDeletePatch is called upon observed CRO/TPO deleteion. It
 	// receives the deleted custom object, the current state as provided by
-	// GetCurrentState. NewDeletePatch analyses the current state
-	// returns the patch state to be applied by Create, Delete, and Update
-	// functions. Create, Delete, and Update are called only when the
-	// corresponding patch state was created.
-	NewDeletePatch(ctx context.Context, obj, currentState interface{}) (*Patch, error)
+	// GetCurrentState and the desired state as provided by
+	// GetDesiredState. NewDeletePatch analyses the current and desired
+	// state returns the patch to be applied by Create, Delete, and Update
+	// functions. ApplyCreatePatch, ApplyDeletePatch, and
+	// ApplyUpdatePatch are called only when the corresponding patch part
+	// was created.
+	NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*Patch, error)
 
-	// Create receives the new custom object observed during TPR watches.
-	// It also receives the Create portion of the Patch provided by
-	// NewUpdatePatch or NewDeletePatch. Create only has to create
+	// ApplyCreatePatch receives the new custom object observed during TPR watches.
+	// It also receives the ApplyCreatePatch portion of the Patch provided by
+	// NewUpdatePatch or NewDeletePatch. ApplyCreatePatch only has to create
 	// resources based on its provided input. All other reconciliation
 	// logic and state transformation is already done at this point of the
 	// reconciliation loop.
-	Create(ctx context.Context, obj, createPatch interface{}) error
-	// Delete receives the new custom object observed during TPR watches.
-	// It also receives the Delete portion of the Patch provided by
-	// NewUpdatePatch or NewDeletePatch. Delete only has to delete
+	ApplyCreatePatch(ctx context.Context, obj, createPatch interface{}) error
+	// ApplyDeletePatch receives the new custom object observed during TPR watches.
+	// It also receives the ApplyDeletePatch portion of the Patch provided by
+	// NewUpdatePatch or NewDeletePatch. ApplyDeletePatch only has to delete
 	// resources based on its provided input. All other reconciliation
 	// logic and state transformation is already done at this point of the
 	// reconciliation loop.
-	Delete(ctx context.Context, obj, deletePatch interface{}) error
-	// Update receives the new custom object observed during TPR watches.
+	ApplyDeletePatch(ctx context.Context, obj, deletePatch interface{}) error
+	// ApplyUpdatePatch receives the new custom object observed during TPR watches.
 	// It also receives the state intended to be updated as provided by
-	// NewUpdatePatch or NewDeletePatch. Update has to update resources
+	// NewUpdatePatch or NewDeletePatch. ApplyUpdatePatch has to update resources
 	// based on its provided input. All other reconciliation logic and
 	// state transformation is already done at this point of the
 	// reconciliation loop.
-	Update(ctx context.Context, obj, updatePatch interface{}) error
+	ApplyUpdatePatch(ctx context.Context, obj, updatePatch interface{}) error
 }

--- a/framework/spec.go
+++ b/framework/spec.go
@@ -5,13 +5,13 @@ import "context"
 type patchType string
 
 const (
-	patchCreate = "create"
-	patchDelete = "delete"
-	patchUpdate = "update"
+	patchCreate patchType = "create"
+	patchDelete patchType = "delete"
+	patchUpdate patchType = "update"
 )
 
 // Patch is a set of information required in order to reconcile to the desired
-// state. Patch is split to three parts: create, delete and update. The parts
+// state. Patch is split into three parts: create, delete and update. The parts
 // are passed as arguments to Resource's Create, Delete and Update functions
 // respectively. Patch is guaranteed to be applied in that order (i.e. create,
 // update, delete).
@@ -44,8 +44,9 @@ func (p *Patch) SetDelete(delete interface{}) { p.data[patchDelete] = delete }
 func (p *Patch) SetUpdate(update interface{}) { p.data[patchUpdate] = update }
 
 // Resource implements the building blocks of any resource business logic being
-// reconciled when observing TPRs. This interface provides a guideline for an
-// easier way to follow the rather complex intentions of operators in general.
+// reconciled when observing custom resources. This interface provides
+// a guideline for an easier way to follow the rather complex intentions of
+// operators in general.
 type Resource interface {
 	// Name returns the resource's name used for identification.
 	Name() string
@@ -58,12 +59,12 @@ type Resource interface {
 	// Underlying can be used for proper identification.
 	Underlying() Resource
 
-	// GetCurrentState receives the custom object observed during TPR watches. Its
-	// purpose is to return the current state of the resources being managed by
-	// the operator. This can e.g. be some actual data within a configmap as
-	// provided by the Kubernetes API. This is not limited to Kubernetes resources
-	// though. Another example would be to fetch and return information about
-	// Flannel bridges.
+	// GetCurrentState receives the custom object observed during custom
+	// resource watches. Its purpose is to return the current state of the
+	// resources being managed by the operator. This can e.g. be some
+	// actual data within a configmap as provided by the Kubernetes API.
+	// This is not limited to Kubernetes resources though. Another example
+	// would be to fetch and return information about Flannel bridges.
 	//
 	// NOTE GetCurrentState is called on create, delete and update events. When
 	// called on create and delete events the provided custom object will be the
@@ -72,14 +73,15 @@ type Resource interface {
 	// then receives the new custom object to be able to consume the current state
 	// of a system.
 	GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error)
-	// GetDesiredState receives the custom object observed during TPR watches. Its
-	// purpose is to return the desired state of the resources being managed by
-	// the operator. The desired state should always be able to be made up using
-	// the information provided by the TPO. This can e.g. be some data within a
-	// configmap, how it should be provided by the Kubernetes API. This is not
-	// limited to Kubernetes resources though. Another example would be to make up
-	// and return information about Flannel bridges, how they should look like on
-	// a server host.
+	// GetDesiredState receives the custom object observed during custom
+	// resource watches. Its purpose is to return the desired state of the
+	// resources being managed by the operator. The desired state should
+	// always be able to be made up using the information provided by the
+	// custom object. This can e.g. be some data within a configmap, how it
+	// should be provided by the Kubernetes API. This is not limited to
+	// Kubernetes resources though. Another example would be to make up and
+	// return information about Flannel bridges, how they should look like
+	// on a server host.
 	//
 	// NOTE GetDesiredState is called on create, delete and update events.
 	// When called on create events the provided custom object will be the
@@ -89,7 +91,7 @@ type Resource interface {
 	// compute the desired state of a system.
 	GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error)
 
-	// NewUpdatePatch is callend upon observed CRO/TPO change. It receives
+	// NewUpdatePatch is callend upon observed custom object change. It receives
 	// the observed custom object, the current state as provided by
 	// GetCurrentState and the desired state as provided by
 	// GetDesiredState. NewUpdatePatch analyses the current and desired
@@ -98,7 +100,7 @@ type Resource interface {
 	// ApplyUpdatePatch are called only when the corresponding patch part
 	// was created.
 	NewUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*Patch, error)
-	// NewDeletePatch is called upon observed CRO/TPO deleteion. It
+	// NewDeletePatch is called upon observed custom object deletion. It
 	// receives the deleted custom object, the current state as provided by
 	// GetCurrentState and the desired state as provided by
 	// GetDesiredState. NewDeletePatch analyses the current and desired
@@ -108,25 +110,25 @@ type Resource interface {
 	// was created.
 	NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*Patch, error)
 
-	// ApplyCreatePatch receives the new custom object observed during TPR watches.
-	// It also receives the ApplyCreatePatch portion of the Patch provided by
-	// NewUpdatePatch or NewDeletePatch. ApplyCreatePatch only has to create
-	// resources based on its provided input. All other reconciliation
-	// logic and state transformation is already done at this point of the
-	// reconciliation loop.
+	// ApplyCreatePatch receives the new custom object observed during
+	// custom resource watches. It also receives the ApplyCreatePatch
+	// portion of the Patch provided by NewUpdatePatch or NewDeletePatch.
+	// ApplyCreatePatch only has to create resources based on its provided
+	// input. All other reconciliation logic and state transformation is
+	// already done at this point of the reconciliation loop.
 	ApplyCreatePatch(ctx context.Context, obj, createPatch interface{}) error
-	// ApplyDeletePatch receives the new custom object observed during TPR watches.
-	// It also receives the ApplyDeletePatch portion of the Patch provided by
-	// NewUpdatePatch or NewDeletePatch. ApplyDeletePatch only has to delete
-	// resources based on its provided input. All other reconciliation
-	// logic and state transformation is already done at this point of the
-	// reconciliation loop.
+	// ApplyDeletePatch receives the new custom object observed during
+	// custom resource watches. It also receives the ApplyDeletePatch
+	// portion of the Patch provided by NewUpdatePatch or NewDeletePatch.
+	// ApplyDeletePatch only has to delete resources based on its provided
+	// input. All other reconciliation logic and state transformation is
+	// already done at this point of the reconciliation loop.
 	ApplyDeletePatch(ctx context.Context, obj, deletePatch interface{}) error
-	// ApplyUpdatePatch receives the new custom object observed during TPR watches.
-	// It also receives the state intended to be updated as provided by
-	// NewUpdatePatch or NewDeletePatch. ApplyUpdatePatch has to update resources
-	// based on its provided input. All other reconciliation logic and
-	// state transformation is already done at this point of the
-	// reconciliation loop.
+	// ApplyUpdatePatch receives the new custom object observed during
+	// custom resource watches. It also receives the state intended to be
+	// updated as provided by NewUpdatePatch or NewDeletePatch.
+	// ApplyUpdatePatch has to update resources based on its provided
+	// input. All other reconciliation logic and state transformation is
+	// already done at this point of the reconciliation loop.
 	ApplyUpdatePatch(ctx context.Context, obj, updatePatch interface{}) error
 }


### PR DESCRIPTION
As we noticed in our operators we often do not really need update, or
want to postpone implementation. E.g. we do not support rolling
certificates, but we want to add that feature later. This require being
able to specify that update part should not be invoked by the framework.

Introduction of Patch struct is a solution to that problem. Create,
Delete and Update functions are called by the framework only when patch
has corresponding parts set.

The Patch is computed in similar way to previous GetUpdateState
function, which is now NewUpdatePatch. NewUpdatePatch function creates
a Patch object when CRO is created or updated. There is also
NewDeletePatch function which is called when CRO is deleted. Both
NewUpdatePatch and NewDeletePatch create Patch struct which in turn is
processed by Create, Delete and Update functions of the Resource.

### framework changes

ProcessAdd is redirected to ProcessUpdate.

ProcessUpdate has following flow:

    current = resource.GetCurrentState(cro)
    desired = resource.GetDesiredState(cro)
    patch = resource.NewUpdatePatch(cro, current, desired)
    patch.hasCreate && resource.Create(cro, patch.getCreate)
    patch.hasDelete && resource.Delete(cro, patch.getDelete)
    patch.hasUpdate && resource.Update(cro, patch.getUpdate)

ProcessDelete has following flow:

    current = resource.GetCurrentState(cro)
    patch = resource.NewDeletePatch(cro, current)
    patch.hasCreate && resource.Create(cro, patch.getCreate)
    patch.hasDelete && resource.Delete(cro, patch.getDelete)
    patch.hasUpdate && resource.Update(cro, patch.getUpdate)