### PR TITLE
Add retry on creating the tpr as well

### DIFF
--- a/tpr/tpr.go
+++ b/tpr/tpr.go
@@ -202,7 +202,7 @@ func (t *TPR) CreateAndWait() error {
 // poll for TPR readiness. Returns alreadyExistsError when the resource already
 // exists.
 func (t *TPR) CreateAndWaitBackOff(initBackOff backoff.BackOff) error {
-	err := t.create()
+	err := t.create(initBackOff)
 	if err != nil {
 		return microerror.Maskf(err, "creating TPR %s", t.name)
 	}
@@ -252,7 +252,7 @@ func (t *TPR) NewInformer(resourceEventHandler cache.ResourceEventHandler, zeroO
 
 // create is extracted for testing because fake REST client does not work.
 // Therefore waitInit can not be tested.
-func (t *TPR) create() error {
+func (t *TPR) create(retry backoff.BackOff) error {
 	tpr := &v1beta1.ThirdPartyResource{
 		ObjectMeta: apismetav1.ObjectMeta{
 			Name: t.name,
@@ -263,13 +263,29 @@ func (t *TPR) create() error {
 		Description: t.description,
 	}
 
-	_, err := t.k8sClient.ExtensionsV1beta1().ThirdPartyResources().Create(tpr)
+	createTpr := func() error {
+		_, err := t.k8sClient.ExtensionsV1beta1().ThirdPartyResources().Create(tpr)
+		if err != nil && apierrors.IsAlreadyExists(err) {
+			return microerror.Mask(alreadyExistsError)
+		}
+		if err != nil {
+			return microerror.Maskf(err, "creating TPR %s", t.name)
+		}
+	}
+
+	// Try creating the TPR once without retry, since I
+	// do not want to retry on the 'alreadyExistsError'.
+	err := createTpr()
 	if err != nil && apierrors.IsAlreadyExists(err) {
 		return microerror.Mask(alreadyExistsError)
 	}
+
+	// Now try creating the TPR with retries.
+	err = backoff.Retry(createTpr, retry)
 	if err != nil {
-		return microerror.Maskf(err, "creating TPR %s", t.name)
+		return microerror.Mask(err)
 	}
+
 	return nil
 }
 

--- a/tpr/tpr.go
+++ b/tpr/tpr.go
@@ -275,11 +275,16 @@ func (t *TPR) create(retry backoff.BackOff) error {
 		return nil
 	}
 
-	// Try creating the TPR once without retry, since I
+	// Try creating the TPR once without a retry, since I
 	// do not want to retry on the 'alreadyExistsError'.
 	err := createTpr()
 	if err != nil && apierrors.IsAlreadyExists(err) {
 		return microerror.Mask(alreadyExistsError)
+	}
+
+	// TPR created succesfully. Don't try to create it again with retries.
+	if err == nil {
+		return nil
 	}
 
 	// Now try creating the TPR with retries.

--- a/tpr/tpr.go
+++ b/tpr/tpr.go
@@ -271,6 +271,8 @@ func (t *TPR) create(retry backoff.BackOff) error {
 		if err != nil {
 			return microerror.Maskf(err, "creating TPR %s", t.name)
 		}
+
+		return nil
 	}
 
 	// Try creating the TPR once without retry, since I

--- a/tpr/tpr_test.go
+++ b/tpr/tpr_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/cenkalti/backoff"
 	"github.com/stretchr/testify/assert"
 
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -122,7 +123,10 @@ func TestCreateTPR(t *testing.T) {
 	resp, err := clientset.ExtensionsV1beta1().ThirdPartyResources().List(apismetav1.ListOptions{})
 	assert.Equal(t, 0, len(resp.Items))
 
-	err = tpr.create()
+	initBackOff := backoff.NewExponentialBackOff()
+	initBackOff.MaxElapsedTime = 10
+
+	err = tpr.create(initBackOff)
 	assert.Nil(t, err)
 
 	resp, err = clientset.ExtensionsV1beta1().ThirdPartyResources().List(apismetav1.ListOptions{})


### PR DESCRIPTION
This will make test environments where the kubernetes-api is started up along with services that want to talk to it right away more reliable.