### PR TITLE
framework: allow desired state for deleted object

### DIFF
--- a/framework/framework_initializer_test.go
+++ b/framework/framework_initializer_test.go
@@ -2,6 +2,7 @@ package framework
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -29,9 +30,9 @@ func Test_Framework_InitCtxFunc_AddFunc(t *testing.T) {
 				return ctx, nil
 			},
 			ExpectedOrder: []string{
-				"GetCurrentState",
-				"GetDesiredState",
-				"NewUpdatePatch",
+				"GetCurrentState(deleted=false)",
+				"GetDesiredState(deleted=false)",
+				"NewPatch",
 				"Create",
 				"Delete",
 				"Update",
@@ -88,9 +89,9 @@ func Test_Framework_InitCtxFunc_DeleteFunc(t *testing.T) {
 				return ctx, nil
 			},
 			ExpectedOrder: []string{
-				"GetCurrentState",
-				"GetDesiredState",
-				"NewDeletePatch",
+				"GetCurrentState(deleted=true)",
+				"GetDesiredState(deleted=true)",
+				"NewPatch",
 				"Create",
 				"Delete",
 				"Update",
@@ -147,9 +148,9 @@ func Test_Framework_InitCtxFunc_UpdateFunc(t *testing.T) {
 				return ctx, nil
 			},
 			ExpectedOrder: []string{
-				"GetCurrentState",
-				"GetDesiredState",
-				"NewUpdatePatch",
+				"GetCurrentState(deleted=false)",
+				"GetDesiredState(deleted=false)",
+				"NewPatch",
 				"Create",
 				"Delete",
 				"Update",
@@ -190,44 +191,30 @@ type testInitCtxFuncResource struct {
 	Order []string
 }
 
-func (r *testInitCtxFuncResource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
+func (r *testInitCtxFuncResource) GetCurrentState(ctx context.Context, obj interface{}, deleted bool) (interface{}, error) {
 	_, ok := testInitCtxFuncFromContext(ctx)
 	if ok {
 		m := "GetCurrentState"
-		r.Order = append(r.Order, m)
+		r.Order = append(r.Order, fmt.Sprintf("%s(deleted=%t)", m, deleted))
 	}
 
 	return nil, nil
 }
 
-func (r *testInitCtxFuncResource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {
+func (r *testInitCtxFuncResource) GetDesiredState(ctx context.Context, obj interface{}, deleted bool) (interface{}, error) {
 	_, ok := testInitCtxFuncFromContext(ctx)
 	if ok {
 		m := "GetDesiredState"
-		r.Order = append(r.Order, m)
+		r.Order = append(r.Order, fmt.Sprintf("%s(deleted=%t)", m, deleted))
 	}
 
 	return nil, nil
 }
 
-func (r *testInitCtxFuncResource) NewUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*Patch, error) {
+func (r *testInitCtxFuncResource) NewPatch(ctx context.Context, obj, currentState, desiredState interface{}) (*Patch, error) {
 	_, ok := testInitCtxFuncFromContext(ctx)
 	if ok {
-		m := "NewUpdatePatch"
-		r.Order = append(r.Order, m)
-	}
-
-	p := NewPatch()
-	p.SetCreateChange("test create state")
-	p.SetUpdateChange("test update state")
-	p.SetDeleteChange("test delete state")
-	return p, nil
-}
-
-func (r *testInitCtxFuncResource) NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*Patch, error) {
-	_, ok := testInitCtxFuncFromContext(ctx)
-	if ok {
-		m := "NewDeletePatch"
+		m := "NewPatch"
 		r.Order = append(r.Order, m)
 	}
 

--- a/framework/framework_test.go
+++ b/framework/framework_test.go
@@ -2,6 +2,7 @@ package framework
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -38,9 +39,9 @@ func Test_Framework_ResourceCallOrder(t *testing.T) {
 			},
 			ExpectedOrders: [][]string{
 				{
-					"GetCurrentState",
-					"GetDesiredState",
-					"NewUpdatePatch",
+					"GetCurrentState(deleted=false)",
+					"GetDesiredState(deleted=false)",
+					"NewPatch",
 					"ApplyCreatePatch",
 					"ApplyDeletePatch",
 					"ApplyUpdatePatch",
@@ -60,17 +61,17 @@ func Test_Framework_ResourceCallOrder(t *testing.T) {
 			},
 			ExpectedOrders: [][]string{
 				{
-					"GetCurrentState",
-					"GetDesiredState",
-					"NewUpdatePatch",
+					"GetCurrentState(deleted=false)",
+					"GetDesiredState(deleted=false)",
+					"NewPatch",
 					"ApplyCreatePatch",
 					"ApplyDeletePatch",
 					"ApplyUpdatePatch",
 				},
 				{
-					"GetCurrentState",
-					"GetDesiredState",
-					"NewUpdatePatch",
+					"GetCurrentState(deleted=false)",
+					"GetDesiredState(deleted=false)",
+					"NewPatch",
 					"ApplyCreatePatch",
 					"ApplyDeletePatch",
 					"ApplyUpdatePatch",
@@ -91,7 +92,7 @@ func Test_Framework_ResourceCallOrder(t *testing.T) {
 			},
 			ExpectedOrders: [][]string{
 				{
-					"GetCurrentState",
+					"GetCurrentState(deleted=false)",
 				},
 			},
 			ErrorMatcher: nil,
@@ -110,9 +111,9 @@ func Test_Framework_ResourceCallOrder(t *testing.T) {
 			},
 			ExpectedOrders: [][]string{
 				{
-					"GetCurrentState",
-					"GetDesiredState",
-					"NewUpdatePatch",
+					"GetCurrentState(deleted=false)",
+					"GetDesiredState(deleted=false)",
+					"NewPatch",
 					"ApplyCreatePatch",
 					"ApplyDeletePatch",
 					"ApplyUpdatePatch",
@@ -129,15 +130,15 @@ func Test_Framework_ResourceCallOrder(t *testing.T) {
 			Ctx:           canceledcontext.NewContext(context.Background(), make(chan struct{})),
 			Resources: []Resource{
 				&testResource{
-					CancelingStep: "NewUpdatePatch",
+					CancelingStep: "NewPatch",
 				},
 				&testResource{},
 			},
 			ExpectedOrders: [][]string{
 				{
-					"GetCurrentState",
-					"GetDesiredState",
-					"NewUpdatePatch",
+					"GetCurrentState(deleted=false)",
+					"GetDesiredState(deleted=false)",
+					"NewPatch",
 				},
 				nil,
 			},
@@ -153,22 +154,22 @@ func Test_Framework_ResourceCallOrder(t *testing.T) {
 			Resources: []Resource{
 				&testResource{},
 				&testResource{
-					CancelingStep: "NewUpdatePatch",
+					CancelingStep: "NewPatch",
 				},
 			},
 			ExpectedOrders: [][]string{
 				{
-					"GetCurrentState",
-					"GetDesiredState",
-					"NewUpdatePatch",
+					"GetCurrentState(deleted=false)",
+					"GetDesiredState(deleted=false)",
+					"NewPatch",
 					"ApplyCreatePatch",
 					"ApplyDeletePatch",
 					"ApplyUpdatePatch",
 				},
 				{
-					"GetCurrentState",
-					"GetDesiredState",
-					"NewUpdatePatch",
+					"GetCurrentState(deleted=false)",
+					"GetDesiredState(deleted=false)",
+					"NewPatch",
 				},
 			},
 			ErrorMatcher: nil,
@@ -194,9 +195,9 @@ func Test_Framework_ResourceCallOrder(t *testing.T) {
 			},
 			ExpectedOrders: [][]string{
 				{
-					"GetCurrentState",
-					"GetDesiredState",
-					"NewDeletePatch",
+					"GetCurrentState(deleted=true)",
+					"GetDesiredState(deleted=true)",
+					"NewPatch",
 					"ApplyCreatePatch",
 					"ApplyDeletePatch",
 					"ApplyUpdatePatch",
@@ -216,17 +217,17 @@ func Test_Framework_ResourceCallOrder(t *testing.T) {
 			},
 			ExpectedOrders: [][]string{
 				{
-					"GetCurrentState",
-					"GetDesiredState",
-					"NewDeletePatch",
+					"GetCurrentState(deleted=true)",
+					"GetDesiredState(deleted=true)",
+					"NewPatch",
 					"ApplyCreatePatch",
 					"ApplyDeletePatch",
 					"ApplyUpdatePatch",
 				},
 				{
-					"GetCurrentState",
-					"GetDesiredState",
-					"NewDeletePatch",
+					"GetCurrentState(deleted=true)",
+					"GetDesiredState(deleted=true)",
+					"NewPatch",
 					"ApplyCreatePatch",
 					"ApplyDeletePatch",
 					"ApplyUpdatePatch",
@@ -247,7 +248,7 @@ func Test_Framework_ResourceCallOrder(t *testing.T) {
 			},
 			ExpectedOrders: [][]string{
 				{
-					"GetCurrentState",
+					"GetCurrentState(deleted=true)",
 				},
 			},
 			ErrorMatcher: nil,
@@ -266,9 +267,9 @@ func Test_Framework_ResourceCallOrder(t *testing.T) {
 			},
 			ExpectedOrders: [][]string{
 				{
-					"GetCurrentState",
-					"GetDesiredState",
-					"NewDeletePatch",
+					"GetCurrentState(deleted=true)",
+					"GetDesiredState(deleted=true)",
+					"NewPatch",
 					"ApplyCreatePatch",
 					"ApplyDeletePatch",
 					"ApplyUpdatePatch",
@@ -285,15 +286,15 @@ func Test_Framework_ResourceCallOrder(t *testing.T) {
 			Ctx:           canceledcontext.NewContext(context.Background(), make(chan struct{})),
 			Resources: []Resource{
 				&testResource{
-					CancelingStep: "NewDeletePatch",
+					CancelingStep: "NewPatch",
 				},
 				&testResource{},
 			},
 			ExpectedOrders: [][]string{
 				{
-					"GetCurrentState",
-					"GetDesiredState",
-					"NewDeletePatch",
+					"GetCurrentState(deleted=true)",
+					"GetDesiredState(deleted=true)",
+					"NewPatch",
 				},
 				nil,
 			},
@@ -309,22 +310,22 @@ func Test_Framework_ResourceCallOrder(t *testing.T) {
 			Resources: []Resource{
 				&testResource{},
 				&testResource{
-					CancelingStep: "NewDeletePatch",
+					CancelingStep: "NewPatch",
 				},
 			},
 			ExpectedOrders: [][]string{
 				{
-					"GetCurrentState",
-					"GetDesiredState",
-					"NewDeletePatch",
+					"GetCurrentState(deleted=true)",
+					"GetDesiredState(deleted=true)",
+					"NewPatch",
 					"ApplyCreatePatch",
 					"ApplyDeletePatch",
 					"ApplyUpdatePatch",
 				},
 				{
-					"GetCurrentState",
-					"GetDesiredState",
-					"NewDeletePatch",
+					"GetCurrentState(deleted=true)",
+					"GetDesiredState(deleted=true)",
+					"NewPatch",
 				},
 			},
 			ErrorMatcher: nil,
@@ -350,9 +351,9 @@ func Test_Framework_ResourceCallOrder(t *testing.T) {
 			},
 			ExpectedOrders: [][]string{
 				{
-					"GetCurrentState",
-					"GetDesiredState",
-					"NewUpdatePatch",
+					"GetCurrentState(deleted=false)",
+					"GetDesiredState(deleted=false)",
+					"NewPatch",
 					"ApplyCreatePatch",
 					"ApplyDeletePatch",
 					"ApplyUpdatePatch",
@@ -372,17 +373,17 @@ func Test_Framework_ResourceCallOrder(t *testing.T) {
 			},
 			ExpectedOrders: [][]string{
 				{
-					"GetCurrentState",
-					"GetDesiredState",
-					"NewUpdatePatch",
+					"GetCurrentState(deleted=false)",
+					"GetDesiredState(deleted=false)",
+					"NewPatch",
 					"ApplyCreatePatch",
 					"ApplyDeletePatch",
 					"ApplyUpdatePatch",
 				},
 				{
-					"GetCurrentState",
-					"GetDesiredState",
-					"NewUpdatePatch",
+					"GetCurrentState(deleted=false)",
+					"GetDesiredState(deleted=false)",
+					"NewPatch",
 					"ApplyCreatePatch",
 					"ApplyDeletePatch",
 					"ApplyUpdatePatch",
@@ -403,7 +404,7 @@ func Test_Framework_ResourceCallOrder(t *testing.T) {
 			},
 			ExpectedOrders: [][]string{
 				{
-					"GetCurrentState",
+					"GetCurrentState(deleted=false)",
 				},
 			},
 			ErrorMatcher: nil,
@@ -422,9 +423,9 @@ func Test_Framework_ResourceCallOrder(t *testing.T) {
 			},
 			ExpectedOrders: [][]string{
 				{
-					"GetCurrentState",
-					"GetDesiredState",
-					"NewUpdatePatch",
+					"GetCurrentState(deleted=false)",
+					"GetDesiredState(deleted=false)",
+					"NewPatch",
 					"ApplyCreatePatch",
 					"ApplyDeletePatch",
 					"ApplyUpdatePatch",
@@ -441,15 +442,15 @@ func Test_Framework_ResourceCallOrder(t *testing.T) {
 			Ctx:           canceledcontext.NewContext(context.Background(), make(chan struct{})),
 			Resources: []Resource{
 				&testResource{
-					CancelingStep: "NewUpdatePatch",
+					CancelingStep: "NewPatch",
 				},
 				&testResource{},
 			},
 			ExpectedOrders: [][]string{
 				{
-					"GetCurrentState",
-					"GetDesiredState",
-					"NewUpdatePatch",
+					"GetCurrentState(deleted=false)",
+					"GetDesiredState(deleted=false)",
+					"NewPatch",
 				},
 				nil,
 			},
@@ -465,22 +466,22 @@ func Test_Framework_ResourceCallOrder(t *testing.T) {
 			Resources: []Resource{
 				&testResource{},
 				&testResource{
-					CancelingStep: "NewUpdatePatch",
+					CancelingStep: "NewPatch",
 				},
 			},
 			ExpectedOrders: [][]string{
 				{
-					"GetCurrentState",
-					"GetDesiredState",
-					"NewUpdatePatch",
+					"GetCurrentState(deleted=false)",
+					"GetDesiredState(deleted=false)",
+					"NewPatch",
 					"ApplyCreatePatch",
 					"ApplyDeletePatch",
 					"ApplyUpdatePatch",
 				},
 				{
-					"GetCurrentState",
-					"GetDesiredState",
-					"NewUpdatePatch",
+					"GetCurrentState(deleted=false)",
+					"GetDesiredState(deleted=false)",
+					"NewPatch",
 				},
 			},
 			ErrorMatcher: nil,
@@ -520,32 +521,32 @@ func Test_Framework_ResourceCallOrder(t *testing.T) {
 			},
 			ExpectedOrders: [][]string{
 				{
-					"GetCurrentState",
-					"GetDesiredState",
-					"NewUpdatePatch",
+					"GetCurrentState(deleted=false)",
+					"GetDesiredState(deleted=false)",
+					"NewPatch",
 				},
 				{
-					"GetCurrentState",
-					"GetDesiredState",
-					"NewUpdatePatch",
+					"GetCurrentState(deleted=false)",
+					"GetDesiredState(deleted=false)",
+					"NewPatch",
 					"ApplyCreatePatch",
 				},
 				{
-					"GetCurrentState",
-					"GetDesiredState",
-					"NewUpdatePatch",
+					"GetCurrentState(deleted=false)",
+					"GetDesiredState(deleted=false)",
+					"NewPatch",
 					"ApplyDeletePatch",
 				},
 				{
-					"GetCurrentState",
-					"GetDesiredState",
-					"NewUpdatePatch",
+					"GetCurrentState(deleted=false)",
+					"GetDesiredState(deleted=false)",
+					"NewPatch",
 					"ApplyUpdatePatch",
 				},
 				{
-					"GetCurrentState",
-					"GetDesiredState",
-					"NewUpdatePatch",
+					"GetCurrentState(deleted=false)",
+					"GetDesiredState(deleted=false)",
+					"NewPatch",
 					"ApplyCreatePatch",
 					"ApplyDeletePatch",
 				},
@@ -587,32 +588,32 @@ func Test_Framework_ResourceCallOrder(t *testing.T) {
 			},
 			ExpectedOrders: [][]string{
 				{
-					"GetCurrentState",
-					"GetDesiredState",
-					"NewDeletePatch",
+					"GetCurrentState(deleted=true)",
+					"GetDesiredState(deleted=true)",
+					"NewPatch",
 				},
 				{
-					"GetCurrentState",
-					"GetDesiredState",
-					"NewDeletePatch",
+					"GetCurrentState(deleted=true)",
+					"GetDesiredState(deleted=true)",
+					"NewPatch",
 					"ApplyCreatePatch",
 				},
 				{
-					"GetCurrentState",
-					"GetDesiredState",
-					"NewDeletePatch",
+					"GetCurrentState(deleted=true)",
+					"GetDesiredState(deleted=true)",
+					"NewPatch",
 					"ApplyDeletePatch",
 				},
 				{
-					"GetCurrentState",
-					"GetDesiredState",
-					"NewDeletePatch",
+					"GetCurrentState(deleted=true)",
+					"GetDesiredState(deleted=true)",
+					"NewPatch",
 					"ApplyUpdatePatch",
 				},
 				{
-					"GetCurrentState",
-					"GetDesiredState",
-					"NewDeletePatch",
+					"GetCurrentState(deleted=true)",
+					"GetDesiredState(deleted=true)",
+					"NewPatch",
 					"ApplyCreatePatch",
 					"ApplyDeletePatch",
 				},
@@ -654,32 +655,32 @@ func Test_Framework_ResourceCallOrder(t *testing.T) {
 			},
 			ExpectedOrders: [][]string{
 				{
-					"GetCurrentState",
-					"GetDesiredState",
-					"NewUpdatePatch",
+					"GetCurrentState(deleted=false)",
+					"GetDesiredState(deleted=false)",
+					"NewPatch",
 				},
 				{
-					"GetCurrentState",
-					"GetDesiredState",
-					"NewUpdatePatch",
+					"GetCurrentState(deleted=false)",
+					"GetDesiredState(deleted=false)",
+					"NewPatch",
 					"ApplyCreatePatch",
 				},
 				{
-					"GetCurrentState",
-					"GetDesiredState",
-					"NewUpdatePatch",
+					"GetCurrentState(deleted=false)",
+					"GetDesiredState(deleted=false)",
+					"NewPatch",
 					"ApplyDeletePatch",
 				},
 				{
-					"GetCurrentState",
-					"GetDesiredState",
-					"NewUpdatePatch",
+					"GetCurrentState(deleted=false)",
+					"GetDesiredState(deleted=false)",
+					"NewPatch",
 					"ApplyUpdatePatch",
 				},
 				{
-					"GetCurrentState",
-					"GetDesiredState",
-					"NewUpdatePatch",
+					"GetCurrentState(deleted=false)",
+					"GetDesiredState(deleted=false)",
+					"NewPatch",
 					"ApplyCreatePatch",
 					"ApplyDeletePatch",
 				},
@@ -721,9 +722,9 @@ type testResource struct {
 	errorCount int
 }
 
-func (r *testResource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
+func (r *testResource) GetCurrentState(ctx context.Context, obj interface{}, deleted bool) (interface{}, error) {
 	m := "GetCurrentState"
-	r.Order = append(r.Order, m)
+	r.Order = append(r.Order, fmt.Sprintf("%s(deleted=%t)", m, deleted))
 
 	if r.CancelingStep == m {
 		canceledcontext.SetCanceled(ctx)
@@ -739,9 +740,9 @@ func (r *testResource) GetCurrentState(ctx context.Context, obj interface{}) (in
 	return nil, nil
 }
 
-func (r *testResource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {
+func (r *testResource) GetDesiredState(ctx context.Context, obj interface{}, deleted bool) (interface{}, error) {
 	m := "GetDesiredState"
-	r.Order = append(r.Order, m)
+	r.Order = append(r.Order, fmt.Sprintf("%s(deleted=%t)", m, deleted))
 
 	if r.CancelingStep == m {
 		canceledcontext.SetCanceled(ctx)
@@ -757,34 +758,8 @@ func (r *testResource) GetDesiredState(ctx context.Context, obj interface{}) (in
 	return nil, nil
 }
 
-func (r *testResource) NewUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*Patch, error) {
-	m := "NewUpdatePatch"
-	r.Order = append(r.Order, m)
-
-	if r.CancelingStep == m {
-		canceledcontext.SetCanceled(ctx)
-		if canceledcontext.IsCanceled(ctx) {
-			return nil, nil
-		}
-	}
-
-	if r.returnErrorFor(m) {
-		return nil, r.Error
-	}
-
-	p := NewPatch()
-	if r.SetupPatchFunc != nil {
-		r.SetupPatchFunc(p)
-	} else {
-		p.SetCreateChange("test create data")
-		p.SetUpdateChange("test update data")
-		p.SetDeleteChange("test delete data")
-	}
-	return p, nil
-}
-
-func (r *testResource) NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*Patch, error) {
-	m := "NewDeletePatch"
+func (r *testResource) NewPatch(ctx context.Context, obj, currentState, desiredState interface{}) (*Patch, error) {
+	m := "NewPatch"
 	r.Order = append(r.Order, m)
 
 	if r.CancelingStep == m {

--- a/framework/resource/logresource/resource.go
+++ b/framework/resource/logresource/resource.go
@@ -60,10 +60,10 @@ func New(config Config) (*Resource, error) {
 	return newResource, nil
 }
 
-func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
+func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}, deleted bool) (interface{}, error) {
 	r.logger.Log("action", "start", "component", "operatorkit", "function", "GetCurrentState")
 
-	v, err := r.resource.GetCurrentState(ctx, obj)
+	v, err := r.resource.GetCurrentState(ctx, obj, deleted)
 	if err != nil {
 		r.logger.Log("action", "error", "component", "operatorkit", "function", "GetCurrentState")
 		return nil, microerror.Mask(err)
@@ -74,10 +74,10 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 	return v, nil
 }
 
-func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {
+func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}, deleted bool) (interface{}, error) {
 	r.logger.Log("action", "start", "component", "operatorkit", "function", "GetDesiredState")
 
-	v, err := r.resource.GetDesiredState(ctx, obj)
+	v, err := r.resource.GetDesiredState(ctx, obj, deleted)
 	if err != nil {
 		r.logger.Log("action", "error", "component", "operatorkit", "function", "GetDesiredState")
 		return nil, microerror.Mask(err)
@@ -88,30 +88,16 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 	return v, nil
 }
 
-func (r *Resource) NewUpdatePatch(ctx context.Context, obj, cur, des interface{}) (*framework.Patch, error) {
-	r.logger.Log("action", "start", "component", "operatorkit", "function", "NewUpdatePatch")
+func (r *Resource) NewPatch(ctx context.Context, obj, cur, des interface{}) (*framework.Patch, error) {
+	r.logger.Log("action", "start", "component", "operatorkit", "function", "NewPatch")
 
-	v, err := r.resource.NewUpdatePatch(ctx, obj, cur, des)
+	v, err := r.resource.NewPatch(ctx, obj, cur, des)
 	if err != nil {
-		r.logger.Log("action", "error", "component", "operatorkit", "function", "NewUpdatePatch")
+		r.logger.Log("action", "error", "component", "operatorkit", "function", "NewPatch")
 		return nil, microerror.Mask(err)
 	}
 
-	r.logger.Log("action", "end", "component", "operatorkit", "function", "NewUpdatePatch")
-
-	return v, nil
-}
-
-func (r *Resource) NewDeletePatch(ctx context.Context, obj, cur, des interface{}) (*framework.Patch, error) {
-	r.logger.Log("action", "start", "component", "operatorkit", "function", "NewDeletePatch")
-
-	v, err := r.resource.NewDeletePatch(ctx, obj, cur, des)
-	if err != nil {
-		r.logger.Log("action", "error", "component", "operatorkit", "function", "NewDeletePatch")
-		return nil, microerror.Mask(err)
-	}
-
-	r.logger.Log("action", "end", "component", "operatorkit", "function", "NewDeletePatch")
+	r.logger.Log("action", "end", "component", "operatorkit", "function", "NewPatch")
 
 	return v, nil
 }

--- a/framework/resource/metricsresource/resource.go
+++ b/framework/resource/metricsresource/resource.go
@@ -70,12 +70,12 @@ func New(config Config) (*Resource, error) {
 	return newResource, nil
 }
 
-func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
+func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}, deleted bool) (interface{}, error) {
 	o := "GetCurrentState"
 
 	defer r.updateMetrics(o, time.Now())
 
-	v, err := r.resource.GetCurrentState(ctx, obj)
+	v, err := r.resource.GetCurrentState(ctx, obj, deleted)
 	if err != nil {
 		r.updateErrorMetrics(o)
 		return nil, microerror.Mask(err)
@@ -84,12 +84,12 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 	return v, nil
 }
 
-func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {
+func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}, deleted bool) (interface{}, error) {
 	o := "GetDesiredState"
 
 	defer r.updateMetrics(o, time.Now())
 
-	v, err := r.resource.GetDesiredState(ctx, obj)
+	v, err := r.resource.GetDesiredState(ctx, obj, deleted)
 	if err != nil {
 		r.updateErrorMetrics(o)
 		return nil, microerror.Mask(err)
@@ -98,26 +98,12 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 	return v, nil
 }
 
-func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*framework.Patch, error) {
-	o := "NewUpdatePatch"
+func (r *Resource) NewPatch(ctx context.Context, obj, currentState, desiredState interface{}) (*framework.Patch, error) {
+	o := "NewPatch"
 
 	defer r.updateMetrics(o, time.Now())
 
-	v, err := r.resource.NewUpdatePatch(ctx, obj, currentState, desiredState)
-	if err != nil {
-		r.updateErrorMetrics(o)
-		return nil, microerror.Mask(err)
-	}
-
-	return v, nil
-}
-
-func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*framework.Patch, error) {
-	o := "NewDeletePatch"
-
-	defer r.updateMetrics(o, time.Now())
-
-	v, err := r.resource.NewDeletePatch(ctx, obj, currentState, desiredState)
+	v, err := r.resource.NewPatch(ctx, obj, currentState, desiredState)
 	if err != nil {
 		r.updateErrorMetrics(o)
 		return nil, microerror.Mask(err)

--- a/framework/resource/metricsresource/resource_test.go
+++ b/framework/resource/metricsresource/resource_test.go
@@ -2,10 +2,12 @@ package metricsresource
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"testing"
 
 	"github.com/giantswarm/operatorkit/framework"
+	"github.com/giantswarm/operatorkit/framework/context/canceledcontext"
 )
 
 // Test_MetricsResource_ProcessCreate_ResourceOrder ensures the resource's
@@ -30,9 +32,9 @@ func Test_MetricsResource_ProcessCreate_ResourceOrder(t *testing.T) {
 	}
 
 	e := []string{
-		"GetCurrentState",
-		"GetDesiredState",
-		"NewUpdatePatch",
+		"GetCurrentState(deleted=false)",
+		"GetDesiredState(deleted=false)",
+		"NewPatch",
 		"ApplyCreatePatch",
 		"ApplyDeletePatch",
 		"ApplyUpdatePatch",
@@ -64,9 +66,9 @@ func Test_MetricsResource_ProcessDelete_ResourceOrder(t *testing.T) {
 	}
 
 	e := []string{
-		"GetCurrentState",
-		"GetDesiredState",
-		"NewDeletePatch",
+		"GetCurrentState(deleted=true)",
+		"GetDesiredState(deleted=true)",
+		"NewPatch",
 		"ApplyCreatePatch",
 		"ApplyDeletePatch",
 		"ApplyUpdatePatch",
@@ -98,9 +100,9 @@ func Test_MetricsResource_ProcessUpdate_ResourceOrder(t *testing.T) {
 	}
 
 	e := []string{
-		"GetCurrentState",
-		"GetDesiredState",
-		"NewUpdatePatch",
+		"GetCurrentState(deleted=false)",
+		"GetDesiredState(deleted=false)",
+		"NewPatch",
 		"ApplyCreatePatch",
 		"ApplyDeletePatch",
 		"ApplyUpdatePatch",
@@ -111,42 +113,75 @@ func Test_MetricsResource_ProcessUpdate_ResourceOrder(t *testing.T) {
 }
 
 type testResource struct {
-	Order []string
+	CancelingStep  string
+	Error          error
+	ErrorCount     int
+	ErrorMethod    string
+	Order          []string
+	SetupPatchFunc func(p *framework.Patch)
+
+	errorCount int
 }
 
-func (r *testResource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
+func (r *testResource) GetCurrentState(ctx context.Context, obj interface{}, deleted bool) (interface{}, error) {
 	m := "GetCurrentState"
-	r.Order = append(r.Order, m)
+	r.Order = append(r.Order, fmt.Sprintf("%s(deleted=%t)", m, deleted))
+
+	if r.CancelingStep == m {
+		canceledcontext.SetCanceled(ctx)
+		if canceledcontext.IsCanceled(ctx) {
+			return nil, nil
+		}
+	}
+
+	if r.returnErrorFor(m) {
+		return nil, r.Error
+	}
 
 	return nil, nil
 }
 
-func (r *testResource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {
+func (r *testResource) GetDesiredState(ctx context.Context, obj interface{}, deleted bool) (interface{}, error) {
 	m := "GetDesiredState"
-	r.Order = append(r.Order, m)
+	r.Order = append(r.Order, fmt.Sprintf("%s(deleted=%t)", m, deleted))
+
+	if r.CancelingStep == m {
+		canceledcontext.SetCanceled(ctx)
+		if canceledcontext.IsCanceled(ctx) {
+			return nil, nil
+		}
+	}
+
+	if r.returnErrorFor(m) {
+		return nil, r.Error
+	}
 
 	return nil, nil
 }
 
-func (r *testResource) NewUpdatePatch(ctx context.Context, obj, cur, des interface{}) (*framework.Patch, error) {
-	m := "NewUpdatePatch"
+func (r *testResource) NewPatch(ctx context.Context, obj, currentState, desiredState interface{}) (*framework.Patch, error) {
+	m := "NewPatch"
 	r.Order = append(r.Order, m)
 
-	p := framework.NewPatch()
-	p.SetCreateChange("test create data")
-	p.SetUpdateChange("test update data")
-	p.SetDeleteChange("test delete data")
-	return p, nil
-}
+	if r.CancelingStep == m {
+		canceledcontext.SetCanceled(ctx)
+		if canceledcontext.IsCanceled(ctx) {
+			return nil, nil
+		}
+	}
 
-func (r *testResource) NewDeletePatch(ctx context.Context, obj, cur, des interface{}) (*framework.Patch, error) {
-	m := "NewDeletePatch"
-	r.Order = append(r.Order, m)
+	if r.returnErrorFor(m) {
+		return nil, r.Error
+	}
 
 	p := framework.NewPatch()
-	p.SetCreateChange("test create data")
-	p.SetUpdateChange("test update data")
-	p.SetDeleteChange("test delete data")
+	if r.SetupPatchFunc != nil {
+		r.SetupPatchFunc(p)
+	} else {
+		p.SetCreateChange("test create data")
+		p.SetUpdateChange("test update data")
+		p.SetDeleteChange("test delete data")
+	}
 	return p, nil
 }
 
@@ -158,12 +193,34 @@ func (r *testResource) ApplyCreateChange(ctx context.Context, obj, createState i
 	m := "ApplyCreatePatch"
 	r.Order = append(r.Order, m)
 
+	if r.CancelingStep == m {
+		canceledcontext.SetCanceled(ctx)
+		if canceledcontext.IsCanceled(ctx) {
+			return nil
+		}
+	}
+
+	if r.returnErrorFor(m) {
+		return r.Error
+	}
+
 	return nil
 }
 
 func (r *testResource) ApplyDeleteChange(ctx context.Context, obj, deleteState interface{}) error {
 	m := "ApplyDeletePatch"
 	r.Order = append(r.Order, m)
+
+	if r.CancelingStep == m {
+		canceledcontext.SetCanceled(ctx)
+		if canceledcontext.IsCanceled(ctx) {
+			return nil
+		}
+	}
+
+	if r.returnErrorFor(m) {
+		return r.Error
+	}
 
 	return nil
 }
@@ -172,9 +229,31 @@ func (r *testResource) ApplyUpdateChange(ctx context.Context, obj, updateState i
 	m := "ApplyUpdatePatch"
 	r.Order = append(r.Order, m)
 
+	if r.CancelingStep == m {
+		canceledcontext.SetCanceled(ctx)
+		if canceledcontext.IsCanceled(ctx) {
+			return nil
+		}
+	}
+
+	if r.returnErrorFor(m) {
+		return r.Error
+	}
+
 	return nil
 }
 
 func (r *testResource) Underlying() framework.Resource {
 	return r
+}
+
+func (r *testResource) returnErrorFor(errorMethod string) bool {
+	ok := r.Error != nil && r.ErrorCount > r.errorCount && r.ErrorMethod == errorMethod
+
+	if ok {
+		r.errorCount++
+		return true
+	}
+
+	return false
 }

--- a/framework/resource/retryresource/resource.go
+++ b/framework/resource/retryresource/resource.go
@@ -79,12 +79,12 @@ type Resource struct {
 	resource framework.Resource
 }
 
-func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
+func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}, deleted bool) (interface{}, error) {
 	var err error
 
 	var v interface{}
 	o := func() error {
-		v, err = r.resource.GetCurrentState(ctx, obj)
+		v, err = r.resource.GetCurrentState(ctx, obj, deleted)
 		if err != nil {
 			return microerror.Mask(err)
 		}
@@ -104,12 +104,12 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 	return v, nil
 }
 
-func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {
+func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}, deleted bool) (interface{}, error) {
 	var err error
 
 	var v interface{}
 	o := func() error {
-		v, err = r.resource.GetDesiredState(ctx, obj)
+		v, err = r.resource.GetDesiredState(ctx, obj, deleted)
 		if err != nil {
 			return microerror.Mask(err)
 		}
@@ -129,12 +129,12 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 	return v, nil
 }
 
-func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*framework.Patch, error) {
+func (r *Resource) NewPatch(ctx context.Context, obj, currentState, desiredState interface{}) (*framework.Patch, error) {
 	var err error
 
 	var v *framework.Patch
 	o := func() error {
-		v, err = r.resource.NewUpdatePatch(ctx, obj, currentState, desiredState)
+		v, err = r.resource.NewPatch(ctx, obj, currentState, desiredState)
 		if err != nil {
 			return microerror.Mask(err)
 		}
@@ -143,32 +143,7 @@ func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentState, desire
 	}
 
 	n := func(err error, dur time.Duration) {
-		r.logger.Log("warning", fmt.Sprintf("retrying 'NewUpdatePatch' due to error (%s)", err.Error()))
-	}
-
-	err = backoff.RetryNotify(o, r.backOff, n)
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
-
-	return v, nil
-}
-
-func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*framework.Patch, error) {
-	var err error
-
-	var v *framework.Patch
-	o := func() error {
-		v, err = r.resource.NewDeletePatch(ctx, obj, currentState, desiredState)
-		if err != nil {
-			return microerror.Mask(err)
-		}
-
-		return nil
-	}
-
-	n := func(err error, dur time.Duration) {
-		r.logger.Log("warning", fmt.Sprintf("retrying 'NewDeletePatch' due to error (%s)", err.Error()))
+		r.logger.Log("warning", fmt.Sprintf("retrying 'NewPatch' due to error (%s)", err.Error()))
 	}
 
 	err = backoff.RetryNotify(o, r.backOff, n)

--- a/framework/resource/retryresource/resource_test.go
+++ b/framework/resource/retryresource/resource_test.go
@@ -3,11 +3,13 @@ package retryresource
 import (
 	"context"
 	"fmt"
+
 	"reflect"
 	"testing"
 
 	"github.com/cenk/backoff"
 	"github.com/giantswarm/operatorkit/framework"
+	"github.com/giantswarm/operatorkit/framework/context/canceledcontext"
 )
 
 // Test_RetryResource_ProcessCreate_ResourceOrder_RetryOnError ensures the
@@ -23,10 +25,10 @@ func Test_RetryResource_ProcessCreate_ResourceOrder_RetryOnError(t *testing.T) {
 			ErrorCount:  1,
 			ErrorMethod: "GetCurrentState",
 			ExpectedMethodOrder: []string{
-				"GetCurrentState",
-				"GetCurrentState",
-				"GetDesiredState",
-				"NewUpdatePatch",
+				"GetCurrentState(deleted=false)",
+				"GetCurrentState(deleted=false)",
+				"GetDesiredState(deleted=false)",
+				"NewPatch",
 				"ApplyCreatePatch",
 				"ApplyDeletePatch",
 				"ApplyUpdatePatch",
@@ -36,11 +38,11 @@ func Test_RetryResource_ProcessCreate_ResourceOrder_RetryOnError(t *testing.T) {
 			ErrorCount:  2,
 			ErrorMethod: "GetCurrentState",
 			ExpectedMethodOrder: []string{
-				"GetCurrentState",
-				"GetCurrentState",
-				"GetCurrentState",
-				"GetDesiredState",
-				"NewUpdatePatch",
+				"GetCurrentState(deleted=false)",
+				"GetCurrentState(deleted=false)",
+				"GetCurrentState(deleted=false)",
+				"GetDesiredState(deleted=false)",
+				"NewPatch",
 				"ApplyCreatePatch",
 				"ApplyDeletePatch",
 				"ApplyUpdatePatch",
@@ -50,9 +52,9 @@ func Test_RetryResource_ProcessCreate_ResourceOrder_RetryOnError(t *testing.T) {
 			ErrorCount:  2,
 			ErrorMethod: "ApplyCreatePatch",
 			ExpectedMethodOrder: []string{
-				"GetCurrentState",
-				"GetDesiredState",
-				"NewUpdatePatch",
+				"GetCurrentState(deleted=false)",
+				"GetDesiredState(deleted=false)",
+				"NewPatch",
 				"ApplyCreatePatch",
 				"ApplyCreatePatch",
 				"ApplyCreatePatch",
@@ -118,9 +120,9 @@ func Test_RetryResource_ProcessCreate_ResourceOrder(t *testing.T) {
 	}
 
 	e := []string{
-		"GetCurrentState",
-		"GetDesiredState",
-		"NewUpdatePatch",
+		"GetCurrentState(deleted=false)",
+		"GetDesiredState(deleted=false)",
+		"NewPatch",
 		"ApplyCreatePatch",
 		"ApplyDeletePatch",
 		"ApplyUpdatePatch",
@@ -143,10 +145,10 @@ func Test_RetryResource_ProcessDelete_ResourceOrder_RetryOnError(t *testing.T) {
 			ErrorCount:  1,
 			ErrorMethod: "GetCurrentState",
 			ExpectedMethodOrder: []string{
-				"GetCurrentState",
-				"GetCurrentState",
-				"GetDesiredState",
-				"NewDeletePatch",
+				"GetCurrentState(deleted=true)",
+				"GetCurrentState(deleted=true)",
+				"GetDesiredState(deleted=true)",
+				"NewPatch",
 				"ApplyCreatePatch",
 				"ApplyDeletePatch",
 				"ApplyUpdatePatch",
@@ -156,11 +158,11 @@ func Test_RetryResource_ProcessDelete_ResourceOrder_RetryOnError(t *testing.T) {
 			ErrorCount:  2,
 			ErrorMethod: "GetCurrentState",
 			ExpectedMethodOrder: []string{
-				"GetCurrentState",
-				"GetCurrentState",
-				"GetCurrentState",
-				"GetDesiredState",
-				"NewDeletePatch",
+				"GetCurrentState(deleted=true)",
+				"GetCurrentState(deleted=true)",
+				"GetCurrentState(deleted=true)",
+				"GetDesiredState(deleted=true)",
+				"NewPatch",
 				"ApplyCreatePatch",
 				"ApplyDeletePatch",
 				"ApplyUpdatePatch",
@@ -170,9 +172,9 @@ func Test_RetryResource_ProcessDelete_ResourceOrder_RetryOnError(t *testing.T) {
 			ErrorCount:  2,
 			ErrorMethod: "ApplyDeletePatch",
 			ExpectedMethodOrder: []string{
-				"GetCurrentState",
-				"GetDesiredState",
-				"NewDeletePatch",
+				"GetCurrentState(deleted=true)",
+				"GetDesiredState(deleted=true)",
+				"NewPatch",
 				"ApplyCreatePatch",
 				"ApplyDeletePatch",
 				"ApplyDeletePatch",
@@ -238,9 +240,9 @@ func Test_RetryResource_ProcessDelete_ResourceOrder(t *testing.T) {
 	}
 
 	e := []string{
-		"GetCurrentState",
-		"GetDesiredState",
-		"NewDeletePatch",
+		"GetCurrentState(deleted=true)",
+		"GetDesiredState(deleted=true)",
+		"NewPatch",
 		"ApplyCreatePatch",
 		"ApplyDeletePatch",
 		"ApplyUpdatePatch",
@@ -263,10 +265,10 @@ func Test_RetryResource_ProcessUpdate_ResourceOrder_RetryOnError(t *testing.T) {
 			ErrorCount:  1,
 			ErrorMethod: "GetCurrentState",
 			ExpectedMethodOrder: []string{
-				"GetCurrentState",
-				"GetCurrentState",
-				"GetDesiredState",
-				"NewUpdatePatch",
+				"GetCurrentState(deleted=false)",
+				"GetCurrentState(deleted=false)",
+				"GetDesiredState(deleted=false)",
+				"NewPatch",
 				"ApplyCreatePatch",
 				"ApplyDeletePatch",
 				"ApplyUpdatePatch",
@@ -276,11 +278,11 @@ func Test_RetryResource_ProcessUpdate_ResourceOrder_RetryOnError(t *testing.T) {
 			ErrorCount:  2,
 			ErrorMethod: "GetCurrentState",
 			ExpectedMethodOrder: []string{
-				"GetCurrentState",
-				"GetCurrentState",
-				"GetCurrentState",
-				"GetDesiredState",
-				"NewUpdatePatch",
+				"GetCurrentState(deleted=false)",
+				"GetCurrentState(deleted=false)",
+				"GetCurrentState(deleted=false)",
+				"GetDesiredState(deleted=false)",
+				"NewPatch",
 				"ApplyCreatePatch",
 				"ApplyDeletePatch",
 				"ApplyUpdatePatch",
@@ -290,9 +292,9 @@ func Test_RetryResource_ProcessUpdate_ResourceOrder_RetryOnError(t *testing.T) {
 			ErrorCount:  2,
 			ErrorMethod: "ApplyUpdatePatch",
 			ExpectedMethodOrder: []string{
-				"GetCurrentState",
-				"GetDesiredState",
-				"NewUpdatePatch",
+				"GetCurrentState(deleted=false)",
+				"GetDesiredState(deleted=false)",
+				"NewPatch",
 				"ApplyCreatePatch",
 				"ApplyDeletePatch",
 				"ApplyUpdatePatch",
@@ -358,9 +360,9 @@ func Test_RetryResource_ProcessUpdate_ResourceOrder(t *testing.T) {
 	}
 
 	e := []string{
-		"GetCurrentState",
-		"GetDesiredState",
-		"NewUpdatePatch",
+		"GetCurrentState(deleted=false)",
+		"GetDesiredState(deleted=false)",
+		"NewPatch",
 		"ApplyCreatePatch",
 		"ApplyDeletePatch",
 		"ApplyUpdatePatch",
@@ -371,17 +373,26 @@ func Test_RetryResource_ProcessUpdate_ResourceOrder(t *testing.T) {
 }
 
 type testResource struct {
-	Error       error
-	ErrorCount  int
-	ErrorMethod string
-	Order       []string
+	CancelingStep  string
+	Error          error
+	ErrorCount     int
+	ErrorMethod    string
+	Order          []string
+	SetupPatchFunc func(p *framework.Patch)
 
 	errorCount int
 }
 
-func (r *testResource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
+func (r *testResource) GetCurrentState(ctx context.Context, obj interface{}, deleted bool) (interface{}, error) {
 	m := "GetCurrentState"
-	r.Order = append(r.Order, m)
+	r.Order = append(r.Order, fmt.Sprintf("%s(deleted=%t)", m, deleted))
+
+	if r.CancelingStep == m {
+		canceledcontext.SetCanceled(ctx)
+		if canceledcontext.IsCanceled(ctx) {
+			return nil, nil
+		}
+	}
 
 	if r.returnErrorFor(m) {
 		return nil, r.Error
@@ -390,9 +401,16 @@ func (r *testResource) GetCurrentState(ctx context.Context, obj interface{}) (in
 	return nil, nil
 }
 
-func (r *testResource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {
+func (r *testResource) GetDesiredState(ctx context.Context, obj interface{}, deleted bool) (interface{}, error) {
 	m := "GetDesiredState"
-	r.Order = append(r.Order, m)
+	r.Order = append(r.Order, fmt.Sprintf("%s(deleted=%t)", m, deleted))
+
+	if r.CancelingStep == m {
+		canceledcontext.SetCanceled(ctx)
+		if canceledcontext.IsCanceled(ctx) {
+			return nil, nil
+		}
+	}
 
 	if r.returnErrorFor(m) {
 		return nil, r.Error
@@ -401,25 +419,29 @@ func (r *testResource) GetDesiredState(ctx context.Context, obj interface{}) (in
 	return nil, nil
 }
 
-func (r *testResource) NewUpdatePatch(ctx context.Context, obj, cur, des interface{}) (*framework.Patch, error) {
-	m := "NewUpdatePatch"
+func (r *testResource) NewPatch(ctx context.Context, obj, currentState, desiredState interface{}) (*framework.Patch, error) {
+	m := "NewPatch"
 	r.Order = append(r.Order, m)
 
-	p := framework.NewPatch()
-	p.SetCreateChange("test create data")
-	p.SetUpdateChange("test update data")
-	p.SetDeleteChange("test delete data")
-	return p, nil
-}
+	if r.CancelingStep == m {
+		canceledcontext.SetCanceled(ctx)
+		if canceledcontext.IsCanceled(ctx) {
+			return nil, nil
+		}
+	}
 
-func (r *testResource) NewDeletePatch(ctx context.Context, obj, cur, des interface{}) (*framework.Patch, error) {
-	m := "NewDeletePatch"
-	r.Order = append(r.Order, m)
+	if r.returnErrorFor(m) {
+		return nil, r.Error
+	}
 
 	p := framework.NewPatch()
-	p.SetCreateChange("test create data")
-	p.SetUpdateChange("test update data")
-	p.SetDeleteChange("test delete data")
+	if r.SetupPatchFunc != nil {
+		r.SetupPatchFunc(p)
+	} else {
+		p.SetCreateChange("test create data")
+		p.SetUpdateChange("test update data")
+		p.SetDeleteChange("test delete data")
+	}
 	return p, nil
 }
 
@@ -430,6 +452,13 @@ func (r *testResource) Name() string {
 func (r *testResource) ApplyCreateChange(ctx context.Context, obj, createState interface{}) error {
 	m := "ApplyCreatePatch"
 	r.Order = append(r.Order, m)
+
+	if r.CancelingStep == m {
+		canceledcontext.SetCanceled(ctx)
+		if canceledcontext.IsCanceled(ctx) {
+			return nil
+		}
+	}
 
 	if r.returnErrorFor(m) {
 		return r.Error
@@ -442,6 +471,13 @@ func (r *testResource) ApplyDeleteChange(ctx context.Context, obj, deleteState i
 	m := "ApplyDeletePatch"
 	r.Order = append(r.Order, m)
 
+	if r.CancelingStep == m {
+		canceledcontext.SetCanceled(ctx)
+		if canceledcontext.IsCanceled(ctx) {
+			return nil
+		}
+	}
+
 	if r.returnErrorFor(m) {
 		return r.Error
 	}
@@ -452,6 +488,13 @@ func (r *testResource) ApplyDeleteChange(ctx context.Context, obj, deleteState i
 func (r *testResource) ApplyUpdateChange(ctx context.Context, obj, updateState interface{}) error {
 	m := "ApplyUpdatePatch"
 	r.Order = append(r.Order, m)
+
+	if r.CancelingStep == m {
+		canceledcontext.SetCanceled(ctx)
+		if canceledcontext.IsCanceled(ctx) {
+			return nil
+		}
+	}
 
 	if r.returnErrorFor(m) {
 		return r.Error


### PR DESCRIPTION
After tyring to apply latest operatorkit changes I discovered it would
be very useful if the desired state was created with the knowledge if
the custom object was created or deleted. This change adds additional
argument `deleted` to GetDesiredState and GetCurrentState (for
consistency). This argument indicates whether the custom object was
deleted or updated.

Examples:

cert-operator: to compute desired state we need to know if the custom
object was deleted to decide if we desire to have certificate created or
deleted.

endpoint-operator: to compute desired state we need to know if the
custom object was deleted to decide if we desire to have IPs added or
removed from endpoint subnet.