### PR TITLE
Handle nil Patch in ProcessUpdate and ProcessDelete

### DIFF
--- a/framework/framework.go
+++ b/framework/framework.go
@@ -280,7 +280,7 @@ func ProcessDelete(ctx context.Context, obj interface{}, resources []Resource) e
 			}
 		}
 
-		if canceledcontext.IsCanceled(ctx) {
+		if canceledcontext.IsCanceled(ctx) || patch == nil {
 			return nil
 		}
 		deleteChange, ok := patch.getDeleteChange()
@@ -386,7 +386,7 @@ func ProcessUpdate(ctx context.Context, obj interface{}, resources []Resource) e
 
 		// Apply the patch.
 
-		if canceledcontext.IsCanceled(ctx) {
+		if canceledcontext.IsCanceled(ctx) || patch == nil {
 			return nil
 		}
 		createState, ok := patch.getCreateChange()

--- a/framework/framework.go
+++ b/framework/framework.go
@@ -267,6 +267,10 @@ func ProcessDelete(ctx context.Context, obj interface{}, resources []Resource) e
 			return microerror.Mask(err)
 		}
 
+		if patch == nil {
+			return microerror.Maskf(executionFailedError, "patch must not be nil")
+		}
+
 		// Apply the patch.
 
 		if canceledcontext.IsCanceled(ctx) {
@@ -280,7 +284,7 @@ func ProcessDelete(ctx context.Context, obj interface{}, resources []Resource) e
 			}
 		}
 
-		if canceledcontext.IsCanceled(ctx) || patch == nil {
+		if canceledcontext.IsCanceled(ctx) {
 			return nil
 		}
 		deleteChange, ok := patch.getDeleteChange()
@@ -384,9 +388,13 @@ func ProcessUpdate(ctx context.Context, obj interface{}, resources []Resource) e
 			return microerror.Mask(err)
 		}
 
+		if patch == nil {
+			return microerror.Maskf(executionFailedError, "patch must not be nil")
+		}
+
 		// Apply the patch.
 
-		if canceledcontext.IsCanceled(ctx) || patch == nil {
+		if canceledcontext.IsCanceled(ctx) {
 			return nil
 		}
 		createState, ok := patch.getCreateChange()

--- a/framework/framework_test.go
+++ b/framework/framework_test.go
@@ -764,7 +764,7 @@ func (r *testResource) NewUpdatePatch(ctx context.Context, obj, currentState, de
 	if r.CancelingStep == m {
 		canceledcontext.SetCanceled(ctx)
 		if canceledcontext.IsCanceled(ctx) {
-			return nil, nil
+			return NewPatch(), nil
 		}
 	}
 
@@ -790,7 +790,7 @@ func (r *testResource) NewDeletePatch(ctx context.Context, obj, currentState, de
 	if r.CancelingStep == m {
 		canceledcontext.SetCanceled(ctx)
 		if canceledcontext.IsCanceled(ctx) {
-			return nil, nil
+			return NewPatch(), nil
 		}
 	}
 

--- a/framework/framework_test.go
+++ b/framework/framework_test.go
@@ -692,7 +692,7 @@ func Test_Framework_ResourceCallOrder(t *testing.T) {
 		err := tc.ProcessMethod(tc.Ctx, nil, tc.Resources)
 		if err != nil {
 			if tc.ErrorMatcher == nil {
-				t.Fatal("test", i+1, "expected", "error matcher", "got", nil)
+				t.Fatal("test", i+1, "expected", nil, "got", "error matcher")
 			} else if !tc.ErrorMatcher(err) {
 				t.Fatal("test", i+1, "expected", true, "got", false)
 			}


### PR DESCRIPTION
Fixes a problem I had earlier with aws-operator crash looping from a panic because the Patch was nil. The resource now returns an empty Patch struct but I think the framework should handle this. WDYT?

See https://github.com/giantswarm/aws-operator/pull/495