### PR TITLE
unify operator bootstrap magic

### DIFF
--- a/framework/backoff_factory.go
+++ b/framework/backoff_factory.go
@@ -1,0 +1,13 @@
+package framework
+
+import (
+	"github.com/cenk/backoff"
+)
+
+func DefaultBackOffFactory() func() backoff.BackOff {
+	return func() backoff.BackOff {
+		b := backoff.NewExponentialBackOff()
+		b.MaxElapsedTime = 0
+		return backoff.WithMaxTries(b, 7)
+	}
+}

--- a/framework/framework.go
+++ b/framework/framework.go
@@ -502,11 +502,15 @@ func ProcessUpdate(ctx context.Context, obj interface{}, resources []Resource) e
 
 func (f *Framework) bootWithError() error {
 	if f.tpr != nil {
+		f.logger.Log("debug", "ensuring third party resource exists")
+
 		err := f.tpr.CreateAndWait()
 		if tpr.IsAlreadyExists(err) {
 			f.logger.Log("debug", "third party resource already exists")
 		} else if err != nil {
 			return microerror.Mask(err)
+		} else {
+			f.logger.Log("debug", "created third party resource")
 		}
 	}
 

--- a/framework/framework_initializer_test.go
+++ b/framework/framework_initializer_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/cenk/backoff"
 	"github.com/giantswarm/micrologger/microloggertest"
+	"github.com/giantswarm/operatorkit/informer/informertest"
+	"github.com/giantswarm/operatorkit/tpr/tprtest"
 )
 
 func Test_Framework_InitCtxFunc_AddFunc(t *testing.T) {
@@ -47,11 +49,13 @@ func Test_Framework_InitCtxFunc_AddFunc(t *testing.T) {
 			c := DefaultConfig()
 
 			c.BackOff = &backoff.StopBackOff{}
+			c.Informer = informertest.New()
 			c.InitCtxFunc = tc.InitCtxFunc
 			c.Logger = microloggertest.New()
 			c.ResourceRouter = NewDefaultResourceRouter([]Resource{
 				r,
 			})
+			c.TPR = tprtest.New()
 
 			var err error
 			f, err = New(c)
@@ -106,11 +110,13 @@ func Test_Framework_InitCtxFunc_DeleteFunc(t *testing.T) {
 			c := DefaultConfig()
 
 			c.BackOff = &backoff.StopBackOff{}
+			c.Informer = informertest.New()
 			c.InitCtxFunc = tc.InitCtxFunc
 			c.Logger = microloggertest.New()
 			c.ResourceRouter = NewDefaultResourceRouter([]Resource{
 				r,
 			})
+			c.TPR = tprtest.New()
 
 			var err error
 			f, err = New(c)
@@ -165,11 +171,13 @@ func Test_Framework_InitCtxFunc_UpdateFunc(t *testing.T) {
 			c := DefaultConfig()
 
 			c.BackOff = &backoff.StopBackOff{}
+			c.Informer = informertest.New()
 			c.InitCtxFunc = tc.InitCtxFunc
 			c.Logger = microloggertest.New()
 			c.ResourceRouter = NewDefaultResourceRouter([]Resource{
 				r,
 			})
+			c.TPR = tprtest.New()
 
 			var err error
 			f, err = New(c)

--- a/framework/framework_initializer_test.go
+++ b/framework/framework_initializer_test.go
@@ -48,7 +48,7 @@ func Test_Framework_InitCtxFunc_AddFunc(t *testing.T) {
 		{
 			c := DefaultConfig()
 
-			c.BackOff = &backoff.StopBackOff{}
+			c.BackOffFactory = func() backoff.BackOff { return &backoff.StopBackOff{} }
 			c.Informer = informertest.New()
 			c.InitCtxFunc = tc.InitCtxFunc
 			c.Logger = microloggertest.New()
@@ -109,7 +109,7 @@ func Test_Framework_InitCtxFunc_DeleteFunc(t *testing.T) {
 		{
 			c := DefaultConfig()
 
-			c.BackOff = &backoff.StopBackOff{}
+			c.BackOffFactory = func() backoff.BackOff { return &backoff.StopBackOff{} }
 			c.Informer = informertest.New()
 			c.InitCtxFunc = tc.InitCtxFunc
 			c.Logger = microloggertest.New()
@@ -170,7 +170,7 @@ func Test_Framework_InitCtxFunc_UpdateFunc(t *testing.T) {
 		{
 			c := DefaultConfig()
 
-			c.BackOff = &backoff.StopBackOff{}
+			c.BackOffFactory = func() backoff.BackOff { return &backoff.StopBackOff{} }
 			c.Informer = informertest.New()
 			c.InitCtxFunc = tc.InitCtxFunc
 			c.Logger = microloggertest.New()

--- a/informer/informertest/informertest.go
+++ b/informer/informertest/informertest.go
@@ -1,0 +1,17 @@
+package informertest
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+type InformerTest struct{}
+
+func New() *InformerTest {
+	return &InformerTest{}
+}
+
+func (i *InformerTest) Watch(ctx context.Context) (chan watch.Event, chan watch.Event, chan error) {
+	return nil, nil, nil
+}

--- a/informer/informertest/informertest_test.go
+++ b/informer/informertest/informertest_test.go
@@ -1,0 +1,7 @@
+package informertest
+
+import "testing"
+
+func Test_InformerTest_New(t *testing.T) {
+	New()
+}

--- a/informer/spec.go
+++ b/informer/spec.go
@@ -1,9 +1,15 @@
 package informer
 
 import (
+	"context"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 )
+
+type Interface interface {
+	Watch(ctx context.Context) (chan watch.Event, chan watch.Event, chan error)
+}
 
 // WatcherFactory is able to create watchers on demand. It takes a watch
 // endpoint and a ZeroObjectFactory to be able to decode watched events.

--- a/tpr/spec.go
+++ b/tpr/spec.go
@@ -4,6 +4,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
+type Interface interface {
+	CreateAndWait() error
+}
+
 // ZeroObjectFuncs provides zero values of an object and objects' list ready to
 // be decoded. The provided zero values must not be reused by zeroObjectFactory.
 type ZeroObjectFactory interface {

--- a/tpr/tprtest/tpr_test.go
+++ b/tpr/tprtest/tpr_test.go
@@ -1,0 +1,7 @@
+package tprtest
+
+import "testing"
+
+func Test_TPRTest_New(t *testing.T) {
+	New()
+}

--- a/tpr/tprtest/tprtest.go
+++ b/tpr/tprtest/tprtest.go
@@ -1,0 +1,11 @@
+package tprtest
+
+type TPRTest struct{}
+
+func New() *TPRTest {
+	return &TPRTest{}
+}
+
+func (i *TPRTest) CreateAndWait() error {
+	return nil
+}


### PR DESCRIPTION
This PR aims to get rid of some boilerplate code we have to carry around in the operator projects to setup the framework. See https://github.com/giantswarm/kvm-operator/pull/244 where this PR is used. 