### PR TITLE
added histogram observations for framework event processing

### DIFF
--- a/framework/framework.go
+++ b/framework/framework.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cenk/backoff"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
+	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/cache"
 
@@ -386,9 +387,13 @@ func (f *Framework) ProcessEvents(ctx context.Context, deleteChan chan watch.Eve
 		for {
 			select {
 			case e := <-deleteChan:
+				t := prometheus.NewTimer(frameworkHistogram.WithLabelValues("delete"))
 				f.DeleteFunc(e.Object)
+				t.ObserveDuration()
 			case e := <-updateChan:
+				t := prometheus.NewTimer(frameworkHistogram.WithLabelValues("update"))
 				f.UpdateFunc(nil, e.Object)
+				t.ObserveDuration()
 			case err := <-errChan:
 				return microerror.Mask(err)
 			case <-ctx.Done():
@@ -456,7 +461,6 @@ func ProcessUpdate(ctx context.Context, obj interface{}, resources []Resource) e
 		if err != nil {
 			return microerror.Mask(err)
 		}
-
 		if patch == nil {
 			return microerror.Maskf(executionFailedError, "patch must not be nil")
 		}

--- a/framework/metric.go
+++ b/framework/metric.go
@@ -1,0 +1,21 @@
+package framework
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	frameworkHistogram = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: "operatorkit",
+			Subsystem: "framework",
+			Name:      "event",
+			Help:      "Histogram for events within the operatorkit framework.",
+		},
+		[]string{"event"},
+	)
+)
+
+func init() {
+	prometheus.MustRegister(frameworkHistogram)
+}


### PR DESCRIPTION
It would be cool to be able to get metrics for the event processing durations. In theory you can already get metrics that are pretty close to the metrics introduced here, but only if you wrap your own resources with the metrics resource. I assume not everybody is doing that or knows about it so I thought it would be good to have a common way of having the overall histogram information of how long delete and update events take. Note that one weird thing is that the update event channel also handles the actual create events. This is because our informer merges create and update events for reasons. WDYT?