### PR TITLE
use summary instead of histogram

### DIFF
--- a/framework/framework.go
+++ b/framework/framework.go
@@ -387,11 +387,11 @@ func (f *Framework) ProcessEvents(ctx context.Context, deleteChan chan watch.Eve
 		for {
 			select {
 			case e := <-deleteChan:
-				t := prometheus.NewTimer(frameworkHistogram.WithLabelValues("delete"))
+				t := prometheus.NewTimer(frameworkEventSummary.WithLabelValues("delete"))
 				f.DeleteFunc(e.Object)
 				t.ObserveDuration()
 			case e := <-updateChan:
-				t := prometheus.NewTimer(frameworkHistogram.WithLabelValues("update"))
+				t := prometheus.NewTimer(frameworkEventSummary.WithLabelValues("update"))
 				f.UpdateFunc(nil, e.Object)
 				t.ObserveDuration()
 			case err := <-errChan:

--- a/framework/metric.go
+++ b/framework/metric.go
@@ -5,17 +5,18 @@ import (
 )
 
 var (
-	frameworkHistogram = prometheus.NewHistogramVec(
-		prometheus.HistogramOpts{
-			Namespace: "operatorkit",
-			Subsystem: "framework",
-			Name:      "event",
-			Help:      "Histogram for events within the operatorkit framework.",
+	frameworkEventSummary = prometheus.NewSummaryVec(
+		prometheus.SummaryOpts{
+			Namespace:  "operatorkit",
+			Subsystem:  "framework",
+			Name:       "event",
+			Help:       "Summary for events within the operatorkit framework.",
+			Objectives: map[float64]float64{},
 		},
 		[]string{"event"},
 	)
 )
 
 func init() {
-	prometheus.MustRegister(frameworkHistogram)
+	prometheus.MustRegister(frameworkEventSummary)
 }


### PR DESCRIPTION
I was thinking about using the histogram in this case and it felt wrong. I maybe still lack a decent understanding of how it should work. Reading a bit in the prometheus docs I thought using a summary would be more appropriate because I understood it can measure more arbitrary buckets automatically. For instance for histograms we need to know which buckets are suitable for the application to get useful data. The operatorkit framework works with arbitrary operators. We cannot know the suitable buckets. 