### PR TITLE
backported CRD client advances for use in tools still being behing

### DIFF
--- a/framework/framework.go
+++ b/framework/framework.go
@@ -666,7 +666,7 @@ func (f *Framework) bootWithError(ctx context.Context) error {
 	if f.crd != nil {
 		f.logger.LogCtx(ctx, "debug", "ensuring custom resource definition exists")
 
-		err := f.crdClient.Ensure(ctx, f.crd, f.backOffFactory())
+		err := f.crdClient.EnsureCreated(ctx, f.crd, f.backOffFactory())
 		if err != nil {
 			return microerror.Mask(err)
 		}


### PR DESCRIPTION
Note this goes into `kubernetes-1.7`. 