### PR TITLE
dep: require k8s.io/api

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -17,9 +17,12 @@
 #   source = "github.com/myfork/project2"
 #
 # [[override]]
-#  name = "github.com/x/y"
-#  version = "2.4.0"
+#   name = "github.com/x/y"
+#   version = "2.4.0"
 
+required = [
+  "k8s.io/api/core/v1"
+]
 
 [[constraint]]
   name = "github.com/cenkalti/backoff"


### PR DESCRIPTION
This solves problem with dependent code like this one:

        $ go build ./...
        # github.com/giantswarm/crdstorage/vendor/k8s.io/client-go/kubernetes/typed/admissionregistration/v1alpha1
        vendor/k8s.io/client-go/kubernetes/typed/admissionregistration/v1alpha1/externaladmissionhookconfiguration.go:36:57: undefined: v1alpha1.ExternalAdmissionHookConfiguration
        vendor/k8s.io/client-go/kubernetes/typed/admissionregistration/v1alpha1/externaladmissionhookconfiguration.go:37:57: undefined: v1alpha1.ExternalAdmissionHookConfiguration
        vendor/k8s.io/client-go/kubernetes/typed/admissionregistration/v1alpha1/externaladmissionhookconfiguration.go:40:44: undefined: v1alpha1.ExternalAdmissionHookConfiguration
        vendor/k8s.io/client-go/kubernetes/typed/admissionregistration/v1alpha1/externaladmissionhookconfiguration.go:41:30: undefined: v1alpha1.ExternalAdmissionHookConfigurationList
        vendor/k8s.io/client-go/kubernetes/typed/admissionregistration/v1alpha1/externaladmissionhookconfiguration.go:43:87: undefined: v1alpha1.ExternalAdmissionHookConfiguration
        vendor/k8s.io/client-go/kubernetes/typed/admissionregistration/v1alpha1/externaladmissionhookconfiguration.go:60:96: undefined: v1alpha1.ExternalAdmissionHookConfiguration
        vendor/k8s.io/client-go/kubernetes/typed/admissionregistration/v1alpha1/externaladmissionhookconfiguration.go:72:82: undefined: v1alpha1.ExternalAdmissionHookConfigurationList
        vendor/k8s.io/client-go/kubernetes/typed/admissionregistration/v1alpha1/externaladmissionhookconfiguration.go:92:144: undefined: v1alpha1.ExternalAdmissionHookConfiguration
        vendor/k8s.io/client-go/kubernetes/typed/admissionregistration/v1alpha1/externaladmissionhookconfiguration.go:103:144: undefined: v1alpha1.ExternalAdmissionHookConfiguration
        vendor/k8s.io/client-go/kubernetes/typed/admissionregistration/v1alpha1/externaladmissionhookconfiguration.go:135:132: undefined: v1alpha1.ExternalAdmissionHookConfiguration
        vendor/k8s.io/client-go/kubernetes/typed/admissionregistration/v1alpha1/externaladmissionhookconfiguration.go:135:132: too many errors
        # github.com/giantswarm/crdstorage/vendor/k8s.io/client-go/kubernetes/typed/extensions/v1beta1
        vendor/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/thirdpartyresource.go:36:40: undefined: v1beta1.ThirdPartyResource
        vendor/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/thirdpartyresource.go:37:40: undefined: v1beta1.ThirdPartyResource
        vendor/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/thirdpartyresource.go:40:44: undefined: v1beta1.ThirdPartyResource
        vendor/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/thirdpartyresource.go:41:30: undefined: v1beta1.ThirdPartyResourceList
        vendor/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/thirdpartyresource.go:43:87: undefined: v1beta1.ThirdPartyResource
        vendor/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/thirdpartyresource.go:60:80: undefined: v1beta1.ThirdPartyResource
        vendor/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/thirdpartyresource.go:72:66: undefined: v1beta1.ThirdPartyResourceList
        vendor/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/thirdpartyresource.go:92:95: undefined: v1beta1.ThirdPartyResource
        vendor/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/thirdpartyresource.go:103:95: undefined: v1beta1.ThirdPartyResource
        vendor/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/thirdpartyresource.go:135:116: undefined: v1beta1.ThirdPartyResource
        vendor/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/thirdpartyresource.go:135:116: too many errors
        FAIL    github.com/giantswarm/crdstorage [build failed]