### PR TITLE
framework: remove Underlying from Resource interface

### DIFF
--- a/framework/crud_resource.go
+++ b/framework/crud_resource.go
@@ -15,6 +15,9 @@ type CRUDResourceConfig struct {
 	// Ops is a set of operations used by CRUDResource to implement the
 	// Resource interface.
 	Ops CRUDResourceOps
+
+	// Name is the resource's name used for identification.
+	Name string
 }
 
 // CRUDResource allows implementing complex CRUD Resrouces in structured way.
@@ -24,6 +27,8 @@ type CRUDResource struct {
 	CRUDResourceOps
 
 	logger micrologger.Logger
+
+	name string
 }
 
 func NewCRUDResource(config CRUDResourceConfig) (*CRUDResource, error) {
@@ -33,11 +38,8 @@ func NewCRUDResource(config CRUDResourceConfig) (*CRUDResource, error) {
 	if config.Ops == nil {
 		return nil, microerror.Maskf(invalidConfigError, "config.Ops must not be empty")
 	}
-	if config.Ops.Name() == "" {
-		return nil, microerror.Maskf(invalidConfigError, "config.Ops.Name() must not be empty")
-	}
-	if config.Ops.Underlying() == nil {
-		return nil, microerror.Maskf(invalidConfigError, "config.Ops.Underlying() must not be empty")
+	if config.Name == "" {
+		return nil, microerror.Maskf(invalidConfigError, "config.Name must not be empty")
 	}
 
 	r := &CRUDResource{
@@ -338,10 +340,10 @@ func (r *CRUDResource) EnsureDeleted(ctx context.Context, obj interface{}) error
 }
 
 func (r *CRUDResource) Name() string {
-	return r.Name()
+	return r.name
 }
 
 // TODO uncomment when Resource interface is redefined.
 //func (r *CRUDResource) Underlying() Resource {
-//	return r.Underlying()
+//	return r
 //}

--- a/framework/crud_resource.go
+++ b/framework/crud_resource.go
@@ -38,6 +38,7 @@ func NewCRUDResource(config CRUDResourceConfig) (*CRUDResource, error) {
 	if config.Ops == nil {
 		return nil, microerror.Maskf(invalidConfigError, "config.Ops must not be empty")
 	}
+
 	if config.Name == "" {
 		return nil, microerror.Maskf(invalidConfigError, "config.Name must not be empty")
 	}

--- a/framework/crud_resource_ops.go
+++ b/framework/crud_resource_ops.go
@@ -7,14 +7,6 @@ import "context"
 // a guideline for an easier way to follow the rather complex intentions of
 // operators in general.
 type CRUDResourceOps interface {
-	// Name returns the resource's name used for identification.
-	Name() string
-	// Underlying returns the underlying CRUDResourceOps wrapped by this
-	// instance. In case this instance is not a wrapper Underlying should
-	// return this instance. This allows nested wrapping. In combination
-	// with Name, Underlying can be used for proper identification.
-	Underlying() Resource
-
 	// GetCurrentState receives the custom object observed during custom
 	// resource watches. Its purpose is to return the current state of the
 	// resources being managed by the operator. This can e.g. be some

--- a/framework/resource/internal/wrapper.go
+++ b/framework/resource/internal/wrapper.go
@@ -1,0 +1,7 @@
+package internal
+
+import "github.com/giantswarm/operatorkit/framework"
+
+type Wrapper interface {
+	Underlying() framework.Resource
+}

--- a/framework/resource/metricsresource/resource.go
+++ b/framework/resource/metricsresource/resource.go
@@ -7,11 +7,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/giantswarm/operatorkit/framework"
-)
-
-const (
-	// Name is the identifier of the resource.
-	Name = "metrics"
+	"github.com/giantswarm/operatorkit/framework/resource/internal"
 )
 
 type Config struct {
@@ -49,7 +45,7 @@ func New(config Config) (*Resource, error) {
 
 func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
 	sl := r.name
-	rl := r.resource.Underlying().Name()
+	rl := r.resource.Name()
 	ol := "GetCurrentState"
 
 	operationCounter.WithLabelValues(sl, rl, ol).Inc()
@@ -68,7 +64,7 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 
 func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {
 	sl := r.name
-	rl := r.resource.Underlying().Name()
+	rl := r.resource.Name()
 	ol := "GetDesiredState"
 
 	operationCounter.WithLabelValues(sl, rl, ol).Inc()
@@ -87,7 +83,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 
 func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*framework.Patch, error) {
 	sl := r.name
-	rl := r.resource.Underlying().Name()
+	rl := r.resource.Name()
 	ol := "NewUpdatePatch"
 
 	operationCounter.WithLabelValues(sl, rl, ol).Inc()
@@ -106,7 +102,7 @@ func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentState, desire
 
 func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*framework.Patch, error) {
 	sl := r.name
-	rl := r.resource.Underlying().Name()
+	rl := r.resource.Name()
 	ol := "NewDeletePatch"
 
 	operationCounter.WithLabelValues(sl, rl, ol).Inc()
@@ -124,12 +120,12 @@ func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desire
 }
 
 func (r *Resource) Name() string {
-	return Name
+	return r.Underlying().Name()
 }
 
 func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createState interface{}) error {
 	sl := r.name
-	rl := r.resource.Underlying().Name()
+	rl := r.resource.Name()
 	ol := "ApplyCreatePatch"
 
 	operationCounter.WithLabelValues(sl, rl, ol).Inc()
@@ -148,7 +144,7 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createState inter
 
 func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteState interface{}) error {
 	sl := r.name
-	rl := r.resource.Underlying().Name()
+	rl := r.resource.Name()
 	ol := "ApplyDeletePatch"
 
 	operationCounter.WithLabelValues(sl, rl, ol).Inc()
@@ -167,7 +163,7 @@ func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteState inter
 
 func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateState interface{}) error {
 	sl := r.name
-	rl := r.resource.Underlying().Name()
+	rl := r.resource.Name()
 	ol := "ApplyUpdatePatch"
 
 	operationCounter.WithLabelValues(sl, rl, ol).Inc()
@@ -185,5 +181,13 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateState inter
 }
 
 func (r *Resource) Underlying() framework.Resource {
-	return r.resource.Underlying()
+	underlying := r.resource
+	for {
+		wrapper, ok := underlying.(internal.Wrapper)
+		if ok {
+			underlying = wrapper.Underlying()
+		} else {
+			return underlying
+		}
+	}
 }

--- a/framework/resource/metricsresource/resource_test.go
+++ b/framework/resource/metricsresource/resource_test.go
@@ -6,7 +6,14 @@ import (
 	"testing"
 
 	"github.com/giantswarm/operatorkit/framework"
+	"github.com/giantswarm/operatorkit/framework/resource/internal"
 )
+
+func Test_Wrapper(t *testing.T) {
+	// This won't compile if the *Resource doesn't implement Wrapper
+	// interface.
+	var _ internal.Wrapper = &Resource{}
+}
 
 // Test_MetricsResource_ProcessDelete_ResourceOrder ensures the resource's
 // methods are executed as expected when deleting resources using the wrapping
@@ -141,8 +148,4 @@ func (r *testResource) ApplyUpdateChange(ctx context.Context, obj, updateState i
 	r.Order = append(r.Order, m)
 
 	return nil
-}
-
-func (r *testResource) Underlying() framework.Resource {
-	return r
 }

--- a/framework/resource/retryresource/resource_test.go
+++ b/framework/resource/retryresource/resource_test.go
@@ -9,7 +9,14 @@ import (
 	"github.com/cenkalti/backoff"
 	"github.com/giantswarm/micrologger/microloggertest"
 	"github.com/giantswarm/operatorkit/framework"
+	"github.com/giantswarm/operatorkit/framework/resource/internal"
 )
+
+func Test_Wrapper(t *testing.T) {
+	// This won't compile if the *Resource doesn't implement Wrapper
+	// interface.
+	var _ internal.Wrapper = &Resource{}
+}
 
 // Test_RetryResource_ProcessDelete_ResourceOrder_RetryOnError ensures the
 // resource's methods are executed as expected when retrying the deletion
@@ -347,10 +354,6 @@ func (r *testResource) ApplyUpdateChange(ctx context.Context, obj, updateState i
 	}
 
 	return nil
-}
-
-func (r *testResource) Underlying() framework.Resource {
-	return r
 }
 
 func (r *testResource) returnErrorFor(errorMethod string) bool {

--- a/framework/spec.go
+++ b/framework/spec.go
@@ -9,14 +9,6 @@ import "context"
 type Resource interface {
 	// Name returns the resource's name used for identification.
 	Name() string
-	// Underlying returns the underlying resource which is wrapped by the calling
-	// resource. Underlying must always return a non nil resource. Otherwise
-	// proper resource chaining and execution cannot be guaranteed. In case a
-	// resource does not wrap any other resource, Underlying must return the
-	// resource that does not wrap any resource. The returned resource is then the
-	// origin, the underlying resource of the chain. In combination with Name,
-	// Underlying can be used for proper identification.
-	Underlying() Resource
 
 	// GetCurrentState receives the custom object observed during custom
 	// resource watches. Its purpose is to return the current state of the


### PR DESCRIPTION
I noticed we don't need the Underlying method in the Resource interface, as we
can handle underlying internally in wrapping resources by checking if they
implement Wrapper interface. From the user perspective this is less confusing.

And also makes it easier to implement wrapping resources for the new WIP CRUDResource.