### PR TITLE
allow missing resource set

### DIFF
--- a/framework/resource_router.go
+++ b/framework/resource_router.go
@@ -25,8 +25,10 @@ func NewResourceRouter(c ResourceRouterConfig) (*ResourceRouter, error) {
 }
 
 // ResourceSet tries to lookup the appropriate resource set based on the
-// received runtime object. There must be exactly one result, otherwise
-// ResourceSet returns an error.
+// received runtime object. There might be not any resource set for an observed
+// runtime object if an operator uses multiple frameworks for reconciliations.
+// There must not be multiple resource sets per observed runtime object though.
+// If this is the case, ResourceSet returns an error.
 func (r *ResourceRouter) ResourceSet(obj interface{}) (*ResourceSet, error) {
 	var found []*ResourceSet
 
@@ -36,9 +38,6 @@ func (r *ResourceRouter) ResourceSet(obj interface{}) (*ResourceSet, error) {
 		}
 	}
 
-	if len(found) == 0 {
-		return nil, microerror.Maskf(executionFailedError, "handling resource set not found")
-	}
 	if len(found) > 1 {
 		return nil, microerror.Maskf(executionFailedError, "multiple handling resource sets found; only single allowed")
 	}


### PR DESCRIPTION
I discovered a problem with the resource routing in https://github.com/giantswarm/aws-operator/pull/795. There we introduce multiple frameworks in order to have different resync periods for different resources. Now it can just happen that a framework has for instance only one resource set with a new version and all old versions will just not be managed by the framework. This means the errors we see are not valid, which means removing the error should be the way to go. We could also add some logging actually. Opinions welcome. 

```
{"caller":"github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/operatorkit/framework/framework.go:162","event":"update","function":"UpdateFunc","level":"error","message":"stop framework reconciliation due to error","stack":"[{/go/src/github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/operatorkit/framework/resource_router.go:40: could not find any resource router} {execution failed}]","time":"2018-02-28 09:33:02.852"}
{"caller":"github.com/giantswarm/aws-operator/service/awsconfig/v7/resource/lifecycle/current.go:8","function":"GetCurrentState","level":"debug","message":"lifecycle resource got executed","object":"/apis/provider.giantswarm.io/v1alpha1/namespaces/default/awsconfigs/df5um","resource":"lifecyclev7","time":"2018-02-28 09:33:32.852"}
{"caller":"github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/operatorkit/framework/framework.go:162","event":"update","function":"UpdateFunc","level":"error","message":"stop framework reconciliation due to error","stack":"[{/go/src/github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/operatorkit/framework/resource_router.go:40: could not find any resource router} {execution failed}]","time":"2018-02-28 09:33:33.853"}
{"caller":"github.com/giantswarm/aws-operator/service/awsconfig/v7/resource/lifecycle/current.go:8","function":"GetCurrentState","level":"debug","message":"lifecycle resource got executed","object":"/apis/provider.giantswarm.io/v1alpha1/namespaces/default/awsconfigs/df5um","resource":"lifecyclev7","time":"2018-02-28 09:34:03.853"}
```