### PR TITLE
actually registers defined metric

### DIFF
--- a/informer/metric.go
+++ b/informer/metric.go
@@ -40,6 +40,7 @@ var (
 )
 
 func init() {
+	prometheus.MustRegister(cacheSizeGauge)
 	prometheus.MustRegister(watcherCloseCounter)
 	prometheus.MustRegister(watchEventCounter)
 }


### PR DESCRIPTION
I was checking on some metrics for our informer and noticed something is missing. I don't know how this could happen but lets maybe register the metrics we tried to collect already. Should help identifying issues in operator memory usage. 