### PR TITLE
Fix flakyness in reconciliation integration testcase

### DIFF
--- a/framework/integration/test/reconciliation/backoff.go
+++ b/framework/integration/test/reconciliation/backoff.go
@@ -1,0 +1,13 @@
+// +build k8srequired
+
+package reconciliation
+
+import (
+	"time"
+
+	"github.com/cenkalti/backoff"
+)
+
+func newConstantBackoff(maxRetries uint64) backoff.BackOff {
+	return backoff.WithMaxTries(backoff.NewConstantBackOff(1*time.Second), uint64(maxRetries))
+}

--- a/framework/integration/test/reconciliation/error.go
+++ b/framework/integration/test/reconciliation/error.go
@@ -1,0 +1,14 @@
+// +build k8srequired
+
+package reconciliation
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var countMismatchError = microerror.New("count mismatch")
+
+// IsCountMismatch asserts countMismatchError.
+func IsCountMismatch(err error) bool {
+	return microerror.Cause(err) == countMismatchError
+}

--- a/framework/integration/test/reconciliation/reconciliation_test.go
+++ b/framework/integration/test/reconciliation/reconciliation_test.go
@@ -92,7 +92,7 @@ func Test_Finalizer_Integration_Reconciliation(t *testing.T) {
 	}
 
 	// We wait the absolute maximum amount of time here:
-	// 20 second ResyncPeriod + 2 second RateWait + 3 second for safety.
+	// 20 second ResyncPeriod + 2 second RateWait + 1 second for safety.
 	// The framework should now add the finalizer and EnsureCreated should be hit
 	// once immediatly.
 	//
@@ -102,7 +102,7 @@ func Test_Finalizer_Integration_Reconciliation(t *testing.T) {
 	//
 	// 		EnsureCreated: 3, EnsureDeleted: 0
 	//
-	time.Sleep(25 * time.Second)
+	time.Sleep(23 * time.Second)
 
 	// We get the object after the framework has been started.
 	resultObj, err := testWrapper.GetObject(objName, testNamespace)
@@ -147,7 +147,7 @@ func Test_Finalizer_Integration_Reconciliation(t *testing.T) {
 	}
 
 	// We wait the absolute maximum amount of time here:
-	// 20 second ResyncPeriod + 2 second RateWait + 3 second for safety.
+	// 20 second ResyncPeriod + 2 second RateWait + 1 second for safety.
 	// The framework should now remove the finalizer and EnsureDeleted should be
 	// hit twice immediatly. See https://github.com/giantswarm/giantswarm/issues/2897
 	//
@@ -158,7 +158,7 @@ func Test_Finalizer_Integration_Reconciliation(t *testing.T) {
 	//
 	// 		EnsureCreated: 3, EnsureDeleted: 4
 	//
-	time.Sleep(25 * time.Second)
+	time.Sleep(23 * time.Second)
 
 	// We get the object after the framework has handled the deletion event.
 	resultObj, err = testWrapper.GetObject(objName, testNamespace)

--- a/framework/integration/test/reconciliation/reconciliation_test.go
+++ b/framework/integration/test/reconciliation/reconciliation_test.go
@@ -91,7 +91,7 @@ func Test_Finalizer_Integration_Reconciliation(t *testing.T) {
 		t.Fatal("expected", nil, "got", err)
 	}
 
-	// We wait the absolute maximum amount of time here:
+	// We use backout with the absolute maximum amount:
 	// 20 second ResyncPeriod + 2 second RateWait + 1 second for safety.
 	// The framework should now add the finalizer and EnsureCreated should be hit
 	// once immediatly.
@@ -102,7 +102,16 @@ func Test_Finalizer_Integration_Reconciliation(t *testing.T) {
 	//
 	// 		EnsureCreated: 3, EnsureDeleted: 0
 	//
-	time.Sleep(23 * time.Second)
+	operation = func() error {
+		if tr.GetCreateCount() != 3 {
+			return microerror.New("EnsureCreated count not correct")
+		}
+		return nil
+	}
+	err = backoff.Retry(operation, backoff.WithMaxTries(backoff.NewConstantBackOff(1*time.Second), uint64(23)))
+	if err != nil {
+		t.Fatal("expected", nil, "got", err)
+	}
 
 	// We get the object after the framework has been started.
 	resultObj, err := testWrapper.GetObject(objName, testNamespace)
@@ -146,7 +155,7 @@ func Test_Finalizer_Integration_Reconciliation(t *testing.T) {
 		t.Fatal("expected", nil, "got", err)
 	}
 
-	// We wait the absolute maximum amount of time here:
+	// We use backout with the absolute maximum amount:
 	// 20 second ResyncPeriod + 2 second RateWait + 1 second for safety.
 	// The framework should now remove the finalizer and EnsureDeleted should be
 	// hit twice immediatly. See https://github.com/giantswarm/giantswarm/issues/2897
@@ -158,7 +167,19 @@ func Test_Finalizer_Integration_Reconciliation(t *testing.T) {
 	//
 	// 		EnsureCreated: 3, EnsureDeleted: 4
 	//
-	time.Sleep(23 * time.Second)
+	operation = func() error {
+		if tr.GetCreateCount() != 3 {
+			return microerror.New("EnsureCreated count not correct")
+		}
+		if tr.GetDeleteCount() != 4 {
+			return microerror.New("EnsureDelete count not correct")
+		}
+		return nil
+	}
+	err = backoff.Retry(operation, backoff.WithMaxTries(backoff.NewConstantBackOff(1*time.Second), uint64(23)))
+	if err != nil {
+		t.Fatal("expected", nil, "got", err)
+	}
 
 	// We get the object after the framework has handled the deletion event.
 	resultObj, err = testWrapper.GetObject(objName, testNamespace)

--- a/framework/integration/test/reconciliation/reconciliation_test.go
+++ b/framework/integration/test/reconciliation/reconciliation_test.go
@@ -5,7 +5,6 @@ package reconciliation
 import (
 	"reflect"
 	"testing"
-	"time"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -104,14 +103,14 @@ func Test_Finalizer_Integration_Reconciliation(t *testing.T) {
 	//
 	operation = func() error {
 		if tr.GetCreateCount() != 3 {
-			return microerror.Newf("EnsureCreated was hit %v times, want %v", tr.GetCreateCount(), 3)
+			return microerror.Maskf(countMismatchError, "EnsureCreated was hit %v times, want %v", tr.GetCreateCount(), 3)
 		}
 		if tr.GetDeleteCount() != 0 {
-			return microerror.Newf("EnsureDeleted was hit %v times, want %v", tr.GetDeleteCount(), 0)
+			return microerror.Maskf(countMismatchError, "EnsureDeleted was hit %v times, want %v", tr.GetDeleteCount(), 0)
 		}
 		return nil
 	}
-	err = backoff.Retry(operation, backoff.WithMaxTries(backoff.NewConstantBackOff(1*time.Second), uint64(24)))
+	err = backoff.Retry(operation, newConstantBackoff(uint64(24)))
 	if err != nil {
 		t.Fatal("expected", nil, "got", err)
 	}
@@ -163,14 +162,14 @@ func Test_Finalizer_Integration_Reconciliation(t *testing.T) {
 	//
 	operation = func() error {
 		if tr.GetCreateCount() != 3 {
-			return microerror.Newf("EnsureCreated was hit %v times, want %v", tr.GetCreateCount(), 3)
+			return microerror.Maskf(countMismatchError, "EnsureCreated was hit %v times, want %v", tr.GetCreateCount(), 3)
 		}
 		if tr.GetDeleteCount() != 4 {
-			return microerror.Newf("EnsureDeleted was hit %v times, want %v", tr.GetDeleteCount(), 4)
+			return microerror.Maskf(countMismatchError, "EnsureDeleted was hit %v times, want %v", tr.GetDeleteCount(), 4)
 		}
 		return nil
 	}
-	err = backoff.Retry(operation, backoff.WithMaxTries(backoff.NewConstantBackOff(1*time.Second), uint64(24)))
+	err = backoff.Retry(operation, newConstantBackoff(uint64(24)))
 	if err != nil {
 		t.Fatal("expected", nil, "got", err)
 	}


### PR DESCRIPTION
This is a simple change that caused flakyness in the test that will need a little bit of explaining:

The framework is configured to reconcile every 10 seconds. This tests counts how often the resource functions of the framework have been called and checks if that's correct.

This test always waits a set amount of time before the check, this was 25 seconds. So 5 seconds to do the operation (add or delete an object) with a lot of room for safety and then two reconciliation periods.

So the overall time it ran was 2*25 + test execution time = 50 to 51 seconds. This lead to the problem: if execution was a little slower but the framework executed very quickly, then it could reconcile 5 times in roughly 51 seconds the test ran. This would cause the test to fail.

So I reduced the wait each time by 2 seconds, so we wait 2*23 = 46 seconds in total now. So we still have a 6 second buffer in total, but are also safe with 4 seconds before the framework reconciles a fifth time.

UPDATE: Using backoff now with 24 seconds, 23 seconds was too little atleast once for me. Really hoping that this is more stable.


TL;DR:
Reducing the safety time individually makes the whole test more stable.