### PR TITLE
Add framework name to log output for finalizers

### DIFF
--- a/framework/finalizer.go
+++ b/framework/finalizer.go
@@ -57,7 +57,7 @@ func (f *Framework) removeFinalizer(ctx context.Context, obj interface{}) error 
 		return microerror.Mask(err)
 	}
 	if patch == nil {
-		f.logger.LogCtx(ctx, "function", "removeFinalizer", "level", "warning", "message", "object is missing a finalizer")
+		f.logger.LogCtx(ctx, "function", "removeFinalizer", "level", "warning", "message", fmt.Sprintf("object is missing finalizer for framework %s", f.name))
 		return nil
 	}
 	p, err := json.Marshal(patch)


### PR DESCRIPTION
Very minor change, this is necessary if multiple frameworks watch the same object. It was not clear which finalizer was missing beforehand.