### PR TITLE
Improve comments/gdoc on resource execution order

### DIFF
--- a/framework/resource.go
+++ b/framework/resource.go
@@ -5,7 +5,7 @@ import "context"
 // Resource is an interface. Resources are the building blocks of the
 // operator's reconciliation logic. Note there can be multiple Resources
 // reconciling the same object in the chain. In that case they are guaranteed
-// to be executed in order one one after another.
+// to be executed in order one after another.
 type Resource interface {
 	// Name returns the resource's name used for identification.
 	Name() string

--- a/framework/resource_set.go
+++ b/framework/resource_set.go
@@ -28,7 +28,8 @@ type ResourceSetConfig struct {
 	// Logger is a usual micrologger instance to emit log messages, if any.
 	Logger micrologger.Logger
 	// Resources is the list of framework resources being executed on runtime
-	// object reconciliation if Handles returns true when asked by the framework.
+	// object reconciliation if Handles returns true when asked by the
+	// framework. Resources are executed in given order.
 	Resources []Resource
 }
 


### PR DESCRIPTION
Add an explicit note about `Resource` execution order to `framework.ResourceSetConfig` as well.