### PR TITLE
removes finalizer in case no resource set handles the runtime object

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -163,7 +163,21 @@ func (c *Controller) DeleteFunc(obj interface{}) {
 	resourceSet, err := c.resourceRouter.ResourceSet(obj)
 	if IsNoResourceSet(err) {
 		// In case the resource router is not able to find any resource set to
-		// handle the reconciled runtime object, we stop here.
+		// handle the reconciled runtime object, we stop here. Note that we just
+		// remove the finalizer regardless because at this point there will never be
+		// a chance to remove it otherwhise because nobody wanted to handle this
+		// runtime object anyway.
+
+		c.logger.Log("level", "debug", "message", "removing finalizer from runtime object")
+
+		err = c.removeFinalizer(obj)
+		if err != nil {
+			c.logger.Log("level", "error", "message", "stop reconciliation due to error", "stack", fmt.Sprintf("%#v", err))
+			return
+		}
+
+		c.logger.Log("level", "debug", "message", "removed finalizer from runtime object")
+
 		return
 	} else if err != nil {
 		c.logger.Log("event", "delete", "function", "DeleteFunc", "level", "error", "message", "stop reconciliation due to error", "stack", fmt.Sprintf("%#v", err))
@@ -186,7 +200,7 @@ func (c *Controller) DeleteFunc(obj interface{}) {
 	if !finalizerskeptcontext.IsKept(ctx) {
 		c.logger.LogCtx(ctx, "event", "delete", "function", "DeleteFunc", "level", "debug", "message", "removing finalizer from runtime object")
 
-		err = c.removeFinalizer(ctx, obj)
+		err = c.removeFinalizer(obj)
 		if err != nil {
 			c.logger.LogCtx(ctx, "event", "delete", "function", "DeleteFunc", "level", "error", "message", "stop reconciliation due to error", "stack", fmt.Sprintf("%#v", err))
 			return

--- a/controller/finalizer.go
+++ b/controller/finalizer.go
@@ -1,7 +1,6 @@
 package controller
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 
@@ -79,7 +78,7 @@ func (f *Controller) addFinalizer(obj interface{}) (bool, error) {
 	return stopReconciliation, nil
 }
 
-func (f *Controller) removeFinalizer(ctx context.Context, obj interface{}) error {
+func (f *Controller) removeFinalizer(obj interface{}) error {
 	patch, path, err := createRemoveFinalizerPatch(obj, f.name)
 	if err != nil {
 		return microerror.Mask(err)


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/3110. 