### PR TITLE
Add extra comments for controller wiring in example operator

### DIFF
--- a/example/memcached-operator/controller/memcached.go
+++ b/example/memcached-operator/controller/memcached.go
@@ -67,6 +67,8 @@ func NewMemcached(config Config) (*Memcached, error) {
 	// you want to reconcile non-CRD objects or to use more sophisticated
 	// object routing.
 
+	// crdClient ensures that the configured CRD exists on the cluster when the
+	// operator boots.
 	var crdClient *k8scrdclient.CRDClient
 	{
 		c := k8scrdclient.Config{
@@ -82,11 +84,15 @@ func NewMemcached(config Config) (*Memcached, error) {
 
 	}
 
+	// resourceRouter is used in more complex operators that support multiple
+	// resources and multiple versions of those resources.
 	resourceRouter, err := newSimpleResourceRouter(resources)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
 
+	// memcachedInformer implements a list watch of the memcachedconfig custom
+	// resources.
 	var memcachedInformer *informer.Informer
 	{
 		c := informer.Config{
@@ -102,6 +108,9 @@ func NewMemcached(config Config) (*Memcached, error) {
 
 	}
 
+	// underlying is the OperatorKit controller. It implements a control loop
+	// that reconciles the current state of the resources towards their
+	// desired state.
 	var underlying *controller.Controller
 	{
 		c := controller.Config{


### PR DESCRIPTION
Adds comments to the controller wiring code in the example operator. To help with the understanding of the example. 