### PR TITLE
increases reset wait time for less alert flapping

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -337,7 +337,7 @@ func (c *Controller) bootWithError(ctx context.Context) error {
 	}
 
 	go func() {
-		resetWait := c.informer.ResyncPeriod() * 2
+		resetWait := c.informer.ResyncPeriod() * 3
 
 		for {
 			select {


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/3195. Since the metrics do not seem to conflict with each other we can try setting up the reset wait time. There might be cases in which reconciliation loops take longer because of what the resources have to do and then the math does not work out on the constant time line. So lets try that. Better ideas welcome. 