### PR TITLE
panics when invalid REST client configured

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -294,7 +294,9 @@ func (c *Controller) UpdateFunc(oldObj, newObj interface{}) {
 	}
 
 	ok, err := c.addFinalizer(obj)
-	if err != nil {
+	if IsInvalidRESTClient(err) {
+		panic("invalid REST client configured for controller")
+	} else if err != nil {
 		c.logger.LogCtx(ctx, "level", "error", "message", "stop reconciliation due to error", "stack", fmt.Sprintf("%#v", err))
 		return
 	}

--- a/controller/error.go
+++ b/controller/error.go
@@ -16,6 +16,13 @@ func IsInvalidConfig(err error) bool {
 	return microerror.Cause(err) == invalidConfigError
 }
 
+var invalidRESTClientError = microerror.New("invalid REST client")
+
+// IsInvalidRESTClient asserts invalidRESTClientError.
+func IsInvalidRESTClient(err error) bool {
+	return microerror.Cause(err) == invalidRESTClientError
+}
+
 var noResourceSetError = microerror.New("no resource set")
 
 // IsNoResourceSet asserts noResourceSetError.

--- a/controller/finalizer.go
+++ b/controller/finalizer.go
@@ -8,6 +8,7 @@ import (
 	"github.com/giantswarm/microerror"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -39,7 +40,9 @@ func (f *Controller) addFinalizer(obj interface{}) (bool, error) {
 			// We get an up to date version of our object from k8s and parse the
 			// response from the RESTClient to runtime object.
 			obj, err := f.restClient.Get().AbsPath(accessor.GetSelfLink()).Do().Get()
-			if err != nil {
+			if runtime.IsNotRegisteredError(err) {
+				return microerror.Mask(invalidRESTClientError)
+			} else if err != nil {
 				return microerror.Mask(err)
 			}
 


### PR DESCRIPTION
While developing I noticed there is a nasty case which we actually expect but it is hard to identify. The REST client configured for the controller has to be of a specific kind. This PR is an attempt to make the error more obvious and get to know about the error faster. 

```
{"caller":"github.com/giantswarm/kvm-operator/vendor/github.com/giantswarm/operatorkit/controller/controller.go:298","event":"update","level":"error","message":"stop reconciliation due to error","object":"/apis/provider.giantswarm.io/v1alpha1/namespaces/default/kvmconfigs/n2ywy","stack":"[{/go/src/github.com/giantswarm/kvm-operator/vendor/github.com/giantswarm/operatorkit/controller/finalizer.go:74: } {/go/src/github.com/giantswarm/kvm-operator/vendor/github.com/giantswarm/operatorkit/controller/finalizer.go:43: } {no kind \"KVMConfig\" is registered for version \"provider.giantswarm.io/v1alpha1\"}]","time":"2018-06-07T16:04:06.421535+00:00"}
```
