### PR TITLE
Add initial version of troubleshooting guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ operators in production.
 
 - [Control Flow Primitives](docs/control_flow_primitives.md)
 - [Keeping Reconciliation Loops Short](docs/keeping_reconciliation_loops_short.md)
-- [Using Finalizers](docs/using_finalizers.md)
 - [Troubleshooting Guide](docs/troubleshooting.md)
+- [Using Finalizers](docs/using_finalizers.md)
 
 ## Current Scope
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ operators in production.
 - [Control Flow Primitives](docs/control_flow_primitives.md)
 - [Keeping Reconciliation Loops Short](docs/keeping_reconciliation_loops_short.md)
 - [Using Finalizers](docs/using_finalizers.md)
+- [Troubleshooting Guide](docs/troubleshooting.md)
 
 ## Current Scope
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -26,7 +26,7 @@ unknown (get clusternetworkconfigs.core.giantswarm.io)
 ```
 
 An improved OperatorKit log message (when CRD name is
-`clusternetworkconfigs.core.giantswarm.io`:
+`clusternetworkconfigs.core.giantswarm.io`):
 
 ```
 controller might be missing RBAC rule for clusternetworkconfigs.core.giantswarm.io CRD

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,29 @@
+# Troubleshooting Tips
+
+When developing operators, there might occasionally be moments when Kubernetes
+APIs or apiserver don't return error message with full context or when the error
+message can be a bit misleading. Purpose of this document is to list some common
+pitfalls that might be hard to debug in some cases and where returned error
+message is not perfectly clear.
+
+## RBAC rules
+
+When `informer.Watch()` is called, it might fail to unknown error:
+`unknown (get clusternetworkconfigs.core.giantswarm.io)`. This error is not very
+descriptive and OperatorKit cannot really improve here since the original error
+is generic `StatusError`.
+
+Root cause here is though missing RBAC rule: Operator must have watch permission
+to used CRD in order to be able to operate on it.
+
+## CRD registration
+
+When creating new CRD for an operator and having everything working, but getting
+an error from `streamwatcher.go` that states `unable to decode an event from the
+watch stream` when an object for corresponding CR is created, one possible
+mistake in this case is missing type registration when using generated CRD
+clientset. When type registration is missing, `client-go` decoder cannot
+recognize event and therefore fails with message like following:
+
+`ERROR: logging before flag.Parse: E0619 13:28:42.006292       1 streamwatcher.go:109] Unable to decode an event from the watch stream: unable to decode watch event: no kind "ClusterNetworkConfig" is registered for version "core.giantswarm.io/v1alpha1"`
+

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -8,13 +8,19 @@ message is not perfectly clear.
 
 ## RBAC rules
 
-When `informer.Watch()` is called, it might fail to unknown error:
-`unknown (get clusternetworkconfigs.core.giantswarm.io)`. This error is not very
-descriptive and OperatorKit cannot really improve here since the original error
-is generic `StatusError`.
+When `informer.Watch()` is called, it might fail with an "unknown error". This
+error is not very descriptive and there is work ongoing towards OperatorKit
+improving logging here as the original error is
+[StatusError](https://github.com/kubernetes/apimachinery/blob/master/pkg/api/errors/errors.go#L39)
+with `ErrStatus.Reason`:
+[Forbidden](https://github.com/kubernetes/apimachinery/blob/master/pkg/apis/meta/v1/types.go#L569)
+Root cause here is a missing RBAC rule. The operator must have watch permission
+for the used CRD in order to be able to operate on it.
 
-Root cause here is though missing RBAC rule: Operator must have watch permission
-to used CRD in order to be able to operate on it.
+```
+unknown (get clusternetworkconfigs.core.giantswarm.io)
+```
+
 
 ## CRD registration
 
@@ -25,5 +31,7 @@ mistake in this case is missing type registration when using generated CRD
 clientset. When type registration is missing, `client-go` decoder cannot
 recognize event and therefore fails with message like following:
 
-`ERROR: logging before flag.Parse: E0619 13:28:42.006292       1 streamwatcher.go:109] Unable to decode an event from the watch stream: unable to decode watch event: no kind "ClusterNetworkConfig" is registered for version "core.giantswarm.io/v1alpha1"`
+```
+ERROR: logging before flag.Parse: E0619 13:28:42.006292       1 streamwatcher.go:109] Unable to decode an event from the watch stream: unable to decode watch event: no kind "ClusterNetworkConfig" is registered for version "core.giantswarm.io/v1alpha1"
+```
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -21,15 +21,16 @@ watch permission for the used CRD in order to be able to operate on it.
 unknown (get clusternetworkconfigs.core.giantswarm.io)
 ```
 
-
 ## CRD registration
 
 When creating new CRD for an operator and having everything working, but getting
 an error from `streamwatcher.go` that states `unable to decode an event from the
 watch stream` when an object for corresponding CR is created, one possible
 mistake in this case is missing type registration when using generated CRD
-clientset. When type registration is missing, `client-go` decoder cannot
-recognize event and therefore fails with message like following:
+clientset. Here is an example for Giant Swarm [apiextensions core type
+registration](https://github.com/giantswarm/apiextensions/blob/master/pkg/apis/core/v1alpha1/register.go#L17).
+When type registration is missing, `client-go` decoder cannot recognize event
+and therefore fails with message like following:
 
 ```
 ERROR: logging before flag.Parse: E0619 13:28:42.006292       1 streamwatcher.go:109] Unable to decode an event from the watch stream: unable to decode watch event: no kind "ClusterNetworkConfig" is registered for version "core.giantswarm.io/v1alpha1"

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -10,12 +10,12 @@ message is not perfectly clear.
 
 When `informer.Watch()` is called, it might fail with an "unknown error". This
 error is not very descriptive and there is work ongoing towards OperatorKit
-improving logging here as the original error is
+improving logging on this as the original error is
 [StatusError](https://github.com/kubernetes/apimachinery/blob/master/pkg/api/errors/errors.go#L39)
 with `ErrStatus.Reason`:
 [Forbidden](https://github.com/kubernetes/apimachinery/blob/master/pkg/apis/meta/v1/types.go#L569)
-Root cause here is a missing RBAC rule. The operator must have watch permission
-for the used CRD in order to be able to operate on it.
+Root cause here is a missing RBAC authorization rule. The operator must have
+watch permission for the used CRD in order to be able to operate on it.
 
 ```
 unknown (get clusternetworkconfigs.core.giantswarm.io)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -8,17 +8,28 @@ message is not perfectly clear.
 
 ## RBAC rules
 
-When `informer.Watch()` is called, it might fail with an "unknown error". This
-error is not very descriptive and there is work ongoing towards OperatorKit
-improving logging on this as the original error is
+When `informer.Watch()` is called, it might fail with an "unknown error". The
+original error is
 [StatusError](https://github.com/kubernetes/apimachinery/blob/master/pkg/api/errors/errors.go#L39)
 with `ErrStatus.Reason`:
-[Forbidden](https://github.com/kubernetes/apimachinery/blob/master/pkg/apis/meta/v1/types.go#L569)
-Root cause here is a missing RBAC authorization rule. The operator must have
-watch permission for the used CRD in order to be able to operate on it.
+[Forbidden](https://github.com/kubernetes/apimachinery/blob/master/pkg/apis/meta/v1/types.go#L569).
+As such when logged it's not very descriptive with its `unknown` message, but
+there is a test for this error in OperatorKit that should catch and produce an
+informative log message referring to possible root cause which is a missing RBAC
+authorization rule. The operator must have watch permission for the used CRD in
+order to be able to operate on it.
+
+Raw `StatusError` log message:
 
 ```
 unknown (get clusternetworkconfigs.core.giantswarm.io)
+```
+
+An improved OperatorKit log message (when CRD name is
+`clusternetworkconfigs.core.giantswarm.io`:
+
+```
+controller might be missing RBAC rule for clusternetworkconfigs.core.giantswarm.io CRD
 ```
 
 ## CRD registration


### PR DESCRIPTION
Purpose of this guide is to document common mistakes that are easy to
make accidentally but hard to debug due to lack of informative error
messages.

Pitfalls listed here are stumbled on once in a while and often it might
take considerable time for multiple developer to figure out what's wrong
when error message is not perfectly clear. Therefore having a central
place to look for common mistakes as a first aid can be useful and save
time.