### PR TITLE
Add error matching for apimachinery StatusError

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -13,7 +13,6 @@ import (
 	"github.com/giantswarm/micrologger/loggermeta"
 	"github.com/prometheus/client_golang/prometheus"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/rest"
 
@@ -238,7 +237,11 @@ func (c *Controller) ProcessEvents(ctx context.Context, deleteChan chan watch.Ev
 				c.UpdateFunc(nil, e.Object)
 				t.ObserveDuration()
 			case err := <-errChan:
-				return microerror.Mask(matchAndTransform(err, c.crd.Name))
+				if IsStatusForbidden(err) {
+					return microerror.Maskf(statusForbiddenError, "controller might be missing RBAC rule for %s CRD", c.crd.Name)
+				} else if err != nil {
+					return microerror.Mask(err)
+				}
 			case <-ctx.Done():
 				return nil
 			}
@@ -443,18 +446,6 @@ func ProcessUpdate(ctx context.Context, obj interface{}, resources []Resource) e
 	}
 
 	return nil
-}
-
-// matchAndTransform matches against known errors and transforms them to
-// OperatorKit errors with more user friendly error message.
-func matchAndTransform(err error, crdName string) error {
-	c := microerror.Cause(err)
-	switch {
-	case errors.IsForbidden(c):
-		return microerror.Maskf(statusForbiddenError, "controller might be missing RBAC rule for %s CRD", crdName)
-	default:
-		return err
-	}
 }
 
 func setLoggerCtxValue(ctx context.Context, key, value string) context.Context {

--- a/controller/error.go
+++ b/controller/error.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"github.com/giantswarm/microerror"
+	"k8s.io/apimachinery/pkg/api/errors"
 )
 
 var executionFailedError = microerror.New("execution failed")
@@ -34,7 +35,22 @@ func IsNoResourceSet(err error) bool {
 
 var statusForbiddenError = microerror.New("status forbidden")
 
-// IsStatusForbiddenError asserts statusForbiddenError.
+// IsStatusForbiddenError asserts statusForbiddenError and apimachinery
+// StatusError with StatusReasonForbidden.
 func IsStatusForbidden(err error) bool {
-	return microerror.Cause(err) == statusForbiddenError
+	if err == nil {
+		return false
+	}
+
+	c := microerror.Cause(err)
+
+	if c == statusForbiddenError {
+		return true
+	}
+
+	if errors.IsForbidden(c) {
+		return true
+	}
+
+	return false
 }

--- a/controller/error.go
+++ b/controller/error.go
@@ -1,6 +1,8 @@
 package controller
 
-import "github.com/giantswarm/microerror"
+import (
+	"github.com/giantswarm/microerror"
+)
 
 var executionFailedError = microerror.New("execution failed")
 
@@ -28,4 +30,11 @@ var noResourceSetError = microerror.New("no resource set")
 // IsNoResourceSet asserts noResourceSetError.
 func IsNoResourceSet(err error) bool {
 	return microerror.Cause(err) == noResourceSetError
+}
+
+var statusForbiddenError = microerror.New("status forbidden")
+
+// IsStatusForbiddenError asserts statusForbiddenError.
+func IsStatusForbidden(err error) bool {
+	return microerror.Cause(err) == statusForbiddenError
 }

--- a/controller/error_test.go
+++ b/controller/error_test.go
@@ -1,0 +1,55 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/giantswarm/microerror"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+var unknownError = microerror.New("unknown error")
+
+func Test_IsStatusForbidden(t *testing.T) {
+	testCases := []struct {
+		name           string
+		err            error
+		expectedResult bool
+	}{
+		{
+			name:           "case 0: match apimachinery StatusError with Forbidden reason",
+			err:            errors.NewForbidden(schema.GroupResource{}, "unittest", nil),
+			expectedResult: true,
+		},
+		{
+			name:           "case 1: match masked apimachinery StatusError with Forbidden reason",
+			err:            microerror.Mask(errors.NewForbidden(schema.GroupResource{}, "unittest", nil)),
+			expectedResult: true,
+		},
+		{
+			name:           "case 2: don't match nil",
+			err:            nil,
+			expectedResult: false,
+		},
+		{
+			name:           "case 3: don't match unknown error",
+			err:            unknownError,
+			expectedResult: false,
+		},
+		{
+			name:           "case 4: don't match apimachinery StatusError with Unauthorized reason",
+			err:            errors.NewUnauthorized(""),
+			expectedResult: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := IsStatusForbidden(tc.err)
+
+			if result != tc.expectedResult {
+				t.Fatalf("IsStatusForbidden(%#v) == %v, expected %v", tc.err, result, tc.expectedResult)
+			}
+		})
+	}
+}


### PR DESCRIPTION
When controller doesn't have RBAC rule for CRD, apimachinery emits
StatusError with Reason: Forbidden. This adds matching against this and
transforms error to statusForbiddenError with user friendly error
message.

An example of log message:
```
{"caller":"github.com/giantswarm/cluster-operator/vendor/github.com/giantswarm/operatorkit/controller/controller.go:249","level":"warning","message":"retrying event processing due to error","stack":"[{/home/tuommaki/go/src/github.com/giantswarm/cluster-operator/vendor/github.com/giantswarm/operatorkit/controller/controller.go:241: } {/home/tuommaki/go/src/github.com/giantswarm/cluster-operator/vendor/github.com/giantswarm/operatorkit/controller/controller.go:454: controller might be missing RBAC rule for clusternetworkconfigs.core.giantswarm.io CRD} {status
forbidden}]","time":"2018-06-21T11:55:41.260692+00:00"}
```