### PR TITLE
adds creation timestamp to informer metrics

### DIFF
--- a/informer/collector.go
+++ b/informer/collector.go
@@ -9,10 +9,21 @@ import (
 )
 
 var (
-	description *prometheus.Desc = prometheus.NewDesc(
+	creationTimestampDescription *prometheus.Desc = prometheus.NewDesc(
+		prometheus.BuildFQName("operatorkit", "informer", "creation_timestamp"),
+		"DeletionTimestamp of watched objects.",
+		[]string{
+			"kind",
+			"name",
+			"namespace",
+		},
+		nil,
+	)
+	deletionTimestampDescription *prometheus.Desc = prometheus.NewDesc(
 		prometheus.BuildFQName("operatorkit", "informer", "deletion_timestamp"),
 		"DeletionTimestamp of watched objects.",
 		[]string{
+			"kind",
 			"name",
 			"namespace",
 		},
@@ -22,7 +33,8 @@ var (
 
 // Describe is used to describe metrics which are exported to Prometheus.
 func (i *Informer) Describe(ch chan<- *prometheus.Desc) {
-	ch <- description
+	ch <- creationTimestampDescription
+	ch <- deletionTimestampDescription
 }
 
 // Collect is called by the Prometheus registry when collecting metrics from
@@ -41,21 +53,39 @@ func (i *Informer) Collect(ch chan<- prometheus.Metric) {
 	for {
 		select {
 		case event, ok := <-watcher.ResultChan():
-			if ok {
-				m, err := meta.Accessor(event.Object)
-				if err != nil {
-					i.logger.Log("level", "error", "message", "could not get accessor for object", "stack", fmt.Sprintf("%#v", err))
-					break
-				}
-				if m.GetDeletionTimestamp() != nil {
-					ch <- prometheus.MustNewConstMetric(
-						description,
-						prometheus.GaugeValue,
-						float64(m.GetDeletionTimestamp().Unix()),
-						m.GetName(),
-						m.GetNamespace(),
-					)
-				}
+			if !ok {
+				continue
+			}
+
+			m, err := meta.Accessor(event.Object)
+			if err != nil {
+				i.logger.Log("level", "error", "message", "could not get meta accessor for object", "stack", fmt.Sprintf("%#v", err))
+				break
+			}
+			t, err := meta.TypeAccessor(event.Object)
+			if err != nil {
+				i.logger.Log("level", "error", "message", "could not get type accessor for object", "stack", fmt.Sprintf("%#v", err))
+				break
+			}
+
+			ch <- prometheus.MustNewConstMetric(
+				creationTimestampDescription,
+				prometheus.GaugeValue,
+				float64(m.GetCreationTimestamp().Unix()),
+				t.GetKind(),
+				m.GetName(),
+				m.GetNamespace(),
+			)
+
+			if m.GetDeletionTimestamp() != nil {
+				ch <- prometheus.MustNewConstMetric(
+					deletionTimestampDescription,
+					prometheus.GaugeValue,
+					float64(m.GetDeletionTimestamp().Unix()),
+					t.GetKind(),
+					m.GetName(),
+					m.GetNamespace(),
+				)
 			}
 		case <-time.After(time.Second):
 			i.logger.Log("level", "debug", "message", "finished collecting metrics")


### PR DESCRIPTION
> Hello monitoring folks. I want to add some metrics to the `node-operator` and wonder why and which way to go. I think it would be good to have metrics about drainer configs timing out. I fear this is a bit like the error threshold issue but maybe you can push me into the right direction. 

See 

- https://gigantic.slack.com/archives/C0E0V16DC/p1531477311000351
- https://github.com/giantswarm/node-operator/blob/e6adce72d2a3b15238237e60299709433724ac4d/service/controller/v1/resource/drainer/create.go#L50-L67