### PR TITLE
adds metrics for time of last updated informer cache

### DIFF
--- a/informer/informer.go
+++ b/informer/informer.go
@@ -384,6 +384,7 @@ func (i *Informer) sendCachedEvents(ctx context.Context, deleteChan, updateChan 
 		return true
 	})
 
+	cacheLastUpdatedGauge.Set(float64(time.Now().Unix()))
 	cacheSizeGauge.Set(float64(count))
 }
 

--- a/informer/metric.go
+++ b/informer/metric.go
@@ -10,6 +10,15 @@ const (
 )
 
 var (
+	cacheLastUpdatedGauge = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: PrometheusNamespace,
+			Subsystem: PrometheusSubsystem,
+			Name:      "cache_last_updated",
+			Help:      "A gauge metric expressing the time of the last cache update.",
+		},
+	)
+
 	cacheSizeGauge = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Namespace: PrometheusNamespace,
@@ -40,6 +49,7 @@ var (
 )
 
 func init() {
+	prometheus.MustRegister(cacheLastUpdatedGauge)
 	prometheus.MustRegister(cacheSizeGauge)
 	prometheus.MustRegister(watcherCloseCounter)
 	prometheus.MustRegister(watchEventCounter)


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/4518. Idea here is to have a metric we can alert on that tells us when the cache update was not done for some time. I will also sort out the alert. 