### PR TITLE
fixes error handling in e2e tests

### DIFF
--- a/controller/integration/test/basic/basic_test.go
+++ b/controller/integration/test/basic/basic_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -132,7 +131,7 @@ func Test_Finalizer_Integration_Basic(t *testing.T) {
 
 	// We verify that our object is completely gone now.
 	_, err = testWrapper.GetObject(configMapName, testNamespace)
-	if !errors.IsNotFound(err) {
+	if !configmap.IsNotFound(err) {
 		t.Fatalf("error == %#v, want NotFound error", err)
 	}
 }

--- a/controller/integration/test/controlflow/controlflow_test.go
+++ b/controller/integration/test/controlflow/controlflow_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
 	"github.com/giantswarm/backoff"
 	"github.com/giantswarm/microerror"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -235,7 +234,7 @@ func Test_Finalizer_Integration_Controlflow(t *testing.T) {
 
 	// We verify that our object is completely gone now.
 	_, err = testWrapper.GetObject(objName, testNamespace)
-	if !errors.IsNotFound(err) {
+	if !nodeconfig.IsNotFound(err) {
 		t.Fatalf("error == %#v, want NotFound error", err)
 	}
 }

--- a/controller/integration/test/parallel/parallel_test.go
+++ b/controller/integration/test/parallel/parallel_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
 	"github.com/giantswarm/backoff"
 	"github.com/giantswarm/microerror"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -196,7 +195,7 @@ func Test_Finalizer_Integration_Parallel(t *testing.T) {
 
 	// We verify that our object is completely gone now.
 	_, err = testWrapperA.GetObject(objName, testNamespace)
-	if !errors.IsNotFound(err) {
+	if !nodeconfig.IsNotFound(err) {
 		t.Fatalf("error == %#v, want NotFound error", err)
 	}
 }

--- a/controller/integration/wrapper/configmap/crud.go
+++ b/controller/integration/wrapper/configmap/crud.go
@@ -5,6 +5,7 @@ package configmap
 import (
 	"github.com/giantswarm/microerror"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -32,7 +33,9 @@ func (w Wrapper) DeleteObject(name, namespace string) error {
 
 func (w Wrapper) GetObject(name, namespace string) (interface{}, error) {
 	configMap, err := w.k8sClient.CoreV1().ConfigMaps(namespace).Get(name, metav1.GetOptions{})
-	if err != nil {
+	if errors.IsNotFound(err) {
+		return nil, microerror.Mask(notFoundError)
+	} else if err != nil {
 		return nil, microerror.Mask(err)
 	}
 

--- a/controller/integration/wrapper/configmap/error.go
+++ b/controller/integration/wrapper/configmap/error.go
@@ -4,6 +4,15 @@ package configmap
 
 import "github.com/giantswarm/microerror"
 
+var notFoundError = &microerror.Error{
+	Kind: "notFoundError",
+}
+
+// IsNotFound asserts notFoundError.
+func IsNotFound(err error) bool {
+	return microerror.Cause(err) == notFoundError
+}
+
 var wrongTypeError = &microerror.Error{
 	Kind: "wrongTypeError",
 }

--- a/controller/integration/wrapper/nodeconfig/crud.go
+++ b/controller/integration/wrapper/nodeconfig/crud.go
@@ -5,6 +5,7 @@ package nodeconfig
 import (
 	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
 	"github.com/giantswarm/microerror"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -32,7 +33,9 @@ func (w Wrapper) DeleteObject(name, namespace string) error {
 
 func (w Wrapper) GetObject(name, namespace string) (interface{}, error) {
 	nodeConfig, err := w.g8sClient.CoreV1alpha1().NodeConfigs(namespace).Get(name, metav1.GetOptions{})
-	if err != nil {
+	if errors.IsNotFound(err) {
+		return nil, microerror.Mask(notFoundError)
+	} else if err != nil {
 		return nil, microerror.Mask(err)
 	}
 

--- a/controller/integration/wrapper/nodeconfig/error.go
+++ b/controller/integration/wrapper/nodeconfig/error.go
@@ -4,6 +4,15 @@ package nodeconfig
 
 import "github.com/giantswarm/microerror"
 
+var notFoundError = &microerror.Error{
+	Kind: "notFoundError",
+}
+
+// IsNotFound asserts notFoundError.
+func IsNotFound(err error) bool {
+	return microerror.Cause(err) == notFoundError
+}
+
 var wrongTypeError = &microerror.Error{
 	Kind: "wrongTypeError",
 }


### PR DESCRIPTION
Earlier I fucked this up when masking errors. The tests were not aligned with our error handling from the get go. This should be sorted now. 