### PR TITLE
controller: add controller and loop keys to log metadata

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -225,8 +225,11 @@ func (c *Controller) ProcessEvents(ctx context.Context, deleteChan chan watch.Ev
 		for {
 			loop++
 
-			ctx = setLoggerCtxValue(ctx, loggerKeyController, c.name)
-			ctx = setLoggerCtxValue(ctx, loggerKeyLoop, strconv.Itoa(loop))
+			// Set loop specific logger context.
+			{
+				ctx = setLoggerCtxValue(ctx, loggerKeyController, c.name)
+				ctx = setLoggerCtxValue(ctx, loggerKeyLoop, strconv.Itoa(loop))
+			}
 
 			select {
 			case e := <-deleteChan:
@@ -234,7 +237,7 @@ func (c *Controller) ProcessEvents(ctx context.Context, deleteChan chan watch.Ev
 
 				t := prometheus.NewTimer(controllerHistogram.WithLabelValues(event))
 
-				// Set logger context.
+				// Set event specific logger context.
 				{
 					ctx = setLoggerCtxValue(ctx, loggerKeyEvent, event)
 
@@ -255,7 +258,7 @@ func (c *Controller) ProcessEvents(ctx context.Context, deleteChan chan watch.Ev
 
 				t := prometheus.NewTimer(controllerHistogram.WithLabelValues(event))
 
-				// Set logger context.
+				// Set event specific logger context.
 				{
 					ctx = setLoggerCtxValue(ctx, loggerKeyEvent, event)
 


### PR DESCRIPTION
Fixes https://github.com/giantswarm/giantswarm/issues/4971.

This also brings improvements to setting logger metadata:

- Sets keys very early in the loop.
- Almost all keys are set in single method of the Controller object.