### PR TITLE
improves connection management

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -133,8 +133,8 @@ func New(config Config) (*Controller, error) {
 	return c, nil
 }
 
-func (c *Controller) Boot() {
-	ctx := context.Background()
+func (c *Controller) Boot(ctx context.Context) {
+	ctx = setLoggerCtxValue(ctx, loggerKeyController, c.name)
 
 	c.bootOnce.Do(func() {
 		operation := func() error {
@@ -239,7 +239,6 @@ func (c *Controller) ProcessEvents(ctx context.Context, deleteChan chan watch.Ev
 
 			// Set loop specific logger context.
 			{
-				ctx = setLoggerCtxValue(ctx, loggerKeyController, c.name)
 				ctx = setLoggerCtxValue(ctx, loggerKeyLoop, strconv.Itoa(loop))
 			}
 

--- a/controller/integration/test/controlflow/controlflow_test.go
+++ b/controller/integration/test/controlflow/controlflow_test.go
@@ -3,6 +3,7 @@
 package controlflow
 
 import (
+	"context"
 	"reflect"
 	"testing"
 	"time"
@@ -33,6 +34,8 @@ const (
 func Test_Finalizer_Integration_Controlflow(t *testing.T) {
 	var err error
 
+	ctx := context.Background()
+
 	var resource *testresource.Resource
 	{
 		c := testresource.Config{
@@ -57,7 +60,7 @@ func Test_Finalizer_Integration_Controlflow(t *testing.T) {
 	{
 		controller := harness.Controller()
 
-		go controller.Boot()
+		go controller.Boot(ctx)
 		select {
 		case <-controller.Booted():
 		case <-time.After(30 * time.Second):

--- a/controller/integration/test/error/error_test.go
+++ b/controller/integration/test/error/error_test.go
@@ -3,6 +3,7 @@
 package error
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -25,6 +26,8 @@ const (
 
 func Test_Controller_Integration_Error(t *testing.T) {
 	var err error
+
+	ctx := context.Background()
 
 	var rA *testresource.Resource
 	{
@@ -85,7 +88,7 @@ func Test_Controller_Integration_Error(t *testing.T) {
 	wrapper.MustSetup(testNamespace)
 	defer wrapper.MustTeardown(testNamespace)
 	controller := wrapper.Controller()
-	go controller.Boot()
+	go controller.Boot(ctx)
 	<-controller.Booted()
 
 	// We create two test objects. One is used by one resource to error out.

--- a/controller/integration/test/parallel/parallel_test.go
+++ b/controller/integration/test/parallel/parallel_test.go
@@ -3,6 +3,7 @@
 package parallel
 
 import (
+	"context"
 	"reflect"
 	"sort"
 	"sync"
@@ -41,6 +42,8 @@ const (
 // check that multiple controllers can function in parallel.
 func Test_Finalizer_Integration_Parallel(t *testing.T) {
 	var err error
+
+	ctx := context.Background()
 
 	var resourceA *testresource.Resource
 	{
@@ -133,9 +136,9 @@ func Test_Finalizer_Integration_Parallel(t *testing.T) {
 		controllerB := harnessB.Controller()
 		controllerC := harnessC.Controller()
 
-		go controllerA.Boot()
-		go controllerB.Boot()
-		go controllerC.Boot()
+		go controllerA.Boot(ctx)
+		go controllerB.Boot(ctx)
+		go controllerC.Boot(ctx)
 		select {
 		case <-controllerA.Booted():
 		case <-time.After(30 * time.Second):

--- a/controller/integration/test/reconciliation/reconciliation_test.go
+++ b/controller/integration/test/reconciliation/reconciliation_test.go
@@ -3,6 +3,7 @@
 package reconciliation
 
 import (
+	"context"
 	"reflect"
 	"testing"
 	"time"
@@ -29,6 +30,8 @@ const (
 // the proper replay and reconciliation of delete events with finalizers.
 func Test_Finalizer_Integration_Reconciliation(t *testing.T) {
 	var err error
+
+	ctx := context.Background()
 
 	var tr *testresource.Resource
 	{
@@ -62,7 +65,7 @@ func Test_Finalizer_Integration_Reconciliation(t *testing.T) {
 	controller := nodeConfigWrapper.Controller()
 
 	// We start the controller.
-	go controller.Boot()
+	go controller.Boot(ctx)
 	<-controller.Booted()
 
 	// We create an object, but add a finalizer of another operator. This will

--- a/controller/integration/test/statusupdate/status_update_test.go
+++ b/controller/integration/test/statusupdate/status_update_test.go
@@ -3,6 +3,7 @@
 package statusupdate
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -30,6 +31,8 @@ const (
 
 func Test_Finalizer_Integration_StatusUpdate(t *testing.T) {
 	var err error
+
+	ctx := context.Background()
 
 	var r controller.Resource
 	{
@@ -66,7 +69,7 @@ func Test_Finalizer_Integration_StatusUpdate(t *testing.T) {
 	{
 		c := nodeConfigWrapper.Controller()
 
-		go c.Boot()
+		go c.Boot(ctx)
 		<-c.Booted()
 	}
 

--- a/example/memcached-operator/main.go
+++ b/example/memcached-operator/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
@@ -98,7 +99,7 @@ func mainWithError() error {
 		}
 	}
 
-	memcachedController.Boot()
+	memcachedController.Boot(context.Background())
 
 	return nil
 }

--- a/informer/informer.go
+++ b/informer/informer.go
@@ -286,7 +286,7 @@ func (i *Informer) newWatcher(ctx context.Context) (watch.Interface, error) {
 				return microerror.Mask(err)
 			case <-found:
 				// fall through
-			case <-time.After(time.Second):
+			case <-time.After(5 * time.Second):
 				return microerror.Mask(initializationTimedOutError)
 			}
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/5043. This PR contains a **breaking change** for the controller boot API. It now takes an additional context, where it before did not take any argument. When you run into compile issues, just pass `ctx` to [`Controller.Boot`](https://godoc.org/github.com/giantswarm/operatorkit/controller#Controller.Boot).