### PR TITLE
controller: add more logs around event processing

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -300,8 +300,6 @@ func (c *Controller) ProcessEvents(ctx context.Context, deleteChan chan watch.Ev
 		case <-ctx.Done():
 			return nil
 		}
-
-		c.logger.LogCtx(ctx, "level", "debug", "message", "reconciled event")
 	}
 }
 
@@ -417,7 +415,7 @@ func (c *Controller) bootWithError(ctx context.Context) error {
 			return microerror.Mask(err)
 		}
 
-		c.logger.LogCtx(ctx, "level", "debug", "message", "stopped processing object events")
+		c.logger.LogCtx(ctx, "level", "debug", "message", "processed processing object events")
 	}
 
 	return nil

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -232,9 +232,6 @@ func (c *Controller) deleteFunc(ctx context.Context, obj interface{}) {
 // ProcessEvents takes the event channels created by the operatorkit informer
 // and executes the controller's event functions accordingly.
 func (c *Controller) ProcessEvents(ctx context.Context, deleteChan chan watch.Event, updateChan chan watch.Event, errChan chan error) error {
-	c.logger.LogCtx(ctx, "level", "debug", "message", "processing object events")
-	defer c.logger.LogCtx(ctx, "level", "debug", "message", "stopped processing object events")
-
 	loop := -1
 
 	for {
@@ -412,10 +409,15 @@ func (c *Controller) bootWithError(ctx context.Context) error {
 
 		deleteChan, updateChan, errChan := c.informer.Watch(ctx)
 		close(c.booted)
+
+		c.logger.LogCtx(ctx, "level", "debug", "message", "processing object events")
+
 		err := c.ProcessEvents(ctx, deleteChan, updateChan, errChan)
 		if err != nil {
 			return microerror.Mask(err)
 		}
+
+		c.logger.LogCtx(ctx, "level", "debug", "message", "stopped processing object events")
 	}
 
 	return nil

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -415,7 +415,7 @@ func (c *Controller) bootWithError(ctx context.Context) error {
 			return microerror.Mask(err)
 		}
 
-		c.logger.LogCtx(ctx, "level", "debug", "message", "processed processing object events")
+		c.logger.LogCtx(ctx, "level", "debug", "message", "processed object events")
 	}
 
 	return nil

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -232,10 +232,10 @@ func (c *Controller) deleteFunc(ctx context.Context, obj interface{}) {
 // ProcessEvents takes the event channels created by the operatorkit informer
 // and executes the controller's event functions accordingly.
 func (c *Controller) ProcessEvents(ctx context.Context, deleteChan chan watch.Event, updateChan chan watch.Event, errChan chan error) error {
-	loop := -1
-
 	c.logger.LogCtx(ctx, "level", "debug", "message", "processing object events")
 	defer c.logger.LogCtx(ctx, "level", "debug", "message", "stopped processing object events")
+
+	loop := -1
 
 	for {
 		loop++


### PR DESCRIPTION
@xh3b4sd noticed there are missing loops, e.g. we have logs with
"loop":"25" and "loop":"27" but no logs with "loop":"26". In some rare
cases we see that controller stops reconciling. We need more diagnostic
information.