### PR TITLE
Add docs for operatorkit resource file structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ operators in production.
 ## Docs
 
 - [Control Flow Primitives](docs/control_flow_primitives.md)
+- [File Structure](docs/file_structure.md)
 - [Keeping Reconciliation Loops Short](docs/keeping_reconciliation_loops_short.md)
 - [Managing CR Status Sub Resources](docs/managing_cr_status_sub_resources.md)
 - [Metrics Provider](docs/metrics_provider.md)

--- a/docs/file_structure.md
+++ b/docs/file_structure.md
@@ -1,0 +1,39 @@
+# Resource File Structure
+
+- operatorkit resources should have a consistent structure to make code
+naviagation easier.
+- Each method of the resource should be saved to a separate file.
+e.g. `create.go` should contain the `EnsureCreated` method.
+- Additional files can be added as needed.
+- Unit test files should have the usual Go `_test` suffix.
+
+## Simple interface
+
+- When using the simple resource interface at least the following files should
+exist.
+
+```
+resource
+└── example
+    ├── create.go
+    ├── delete.go
+    ├── error.go
+    └── resource.go
+```
+
+## CRUD interface
+
+- When using the CRUD resource interface at least the following files should
+exist.
+
+```
+resource
+└── example
+    ├── create.go
+    ├── current.go
+    ├── delete.go
+    ├── desired.go
+    ├── error.go
+    ├── resource.go
+    └── update.go
+```

--- a/docs/file_structure.md
+++ b/docs/file_structure.md
@@ -1,4 +1,4 @@
-# Resource File Structure
+# File Structure
 
 - operatorkit resources should have a consistent structure to make code
 naviagation easier.


### PR DESCRIPTION
Follow up to https://github.com/giantswarm/chart-operator/pull/200#issuecomment-465210850.

Just covers the resource file structure for now. We can extend later to controllers etc if that's needed.