### PR TITLE
k8srestconfig: fix string format

### DIFF
--- a/client/k8srestconfig/k8s_rest_config.go
+++ b/client/k8srestconfig/k8s_rest_config.go
@@ -117,7 +117,7 @@ func New(config Config) (*rest.Config, error) {
 		return nil, microerror.Maskf(invalidConfigError, "cannot use %T.Address and %T.KubeConfig", config)
 	}
 	if config.InCluster && config.KubeConfig != "" {
-		return nil, microerror.Maskf(invalidConfigError, "cannot use %T.InCluster and %T.KubeConfig", config)
+		return nil, microerror.Maskf(invalidConfigError, "cannot use %T.InCluster and %T.KubeConfig", config, config)
 	}
 
 	if config.Address != "" {

--- a/client/k8srestconfig/k8s_rest_config.go
+++ b/client/k8srestconfig/k8s_rest_config.go
@@ -111,10 +111,10 @@ func New(config Config) (*rest.Config, error) {
 
 	// Settings.
 	if config.Address == "" && !config.InCluster && config.KubeConfig == "" {
-		return nil, microerror.Maskf(invalidConfigError, "%T.Address must not be empty when not using %T.InCluster or %T.KubeConfig", config)
+		return nil, microerror.Maskf(invalidConfigError, "%T.Address must not be empty when not using %T.InCluster or %T.KubeConfig", config, config, config)
 	}
 	if config.Address != "" && config.KubeConfig != "" {
-		return nil, microerror.Maskf(invalidConfigError, "cannot use %T.Address and %T.KubeConfig", config)
+		return nil, microerror.Maskf(invalidConfigError, "cannot use %T.Address and %T.KubeConfig", config, config)
 	}
 	if config.InCluster && config.KubeConfig != "" {
 		return nil, microerror.Maskf(invalidConfigError, "cannot use %T.InCluster and %T.KubeConfig", config, config)
@@ -123,7 +123,7 @@ func New(config Config) (*rest.Config, error) {
 	if config.Address != "" {
 		_, err := url.Parse(config.Address)
 		if err != nil {
-			return nil, microerror.Maskf(invalidConfigError, "%T.Address=%s must be a valid URL: %s", config, config.Address, err)
+			return nil, microerror.Maskf(invalidConfigError, "%T.Address=%#q must be a valid URL: %s", config, config.Address, err)
 		}
 	}
 	if config.Timeout.Seconds() == 0 {


### PR DESCRIPTION
giantswarm/operatorkit/client/k8srestconfig/k8s_rest_config.go:120: cannot use k8srestconfig.Config.InCluster and %!T(MISSING).KubeConfig} {invalid config error}]