### PR TITLE
Fixes constantly growing context

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -240,12 +240,15 @@ func (c *Controller) deleteFunc(ctx context.Context, obj interface{}) {
 func (c *Controller) ProcessEvents(ctx context.Context, deleteChan chan watch.Event, updateChan chan watch.Event, errChan chan error) error {
 	loop := -1
 
+	// Memorise the original context to avoid growing the context forever.
+	oldCtx := ctx
+
 	for {
 		loop++
 
 		// Set loop specific logger context.
 		{
-			ctx = setLoggerCtxValue(ctx, loggerKeyLoop, strconv.Itoa(loop))
+			ctx = setLoggerCtxValue(oldCtx, loggerKeyLoop, strconv.Itoa(loop))
 		}
 
 		select {


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/6416

As we're using the same context forever, it constantly grows, meaning the operators eventually OOM.

With this, we memorise the original context, which means the context does not grow forever.

From a limited trial (~1 hour), operator memory looks much more stable. Realistically, we'll need to run this for a while to see if it stabilises memory over the longer term.

Without patch:
```
context.Background.WithValue("loggerMeta", &loggermeta.LoggerMeta{KeyVals:map[string]string{"controller":"kvm-operator", "loop":"5", "event":"update", "object":"/apis/provider.giantswarm.io/v1alpha1/namespaces/default/kvmconfigs/ca59h", "version":"125941581", "resource":"status"}}).WithValue("loggerMeta", &loggermeta.LoggerMeta{KeyVals:map[string]string{"controller":"kvm-operator", "loop":"5", "event":"update", "object":"/apis/provider.giantswarm.io/v1alpha1/namespaces/default/kvmconfigs/ca59h", "version":"125941581", "resource":"status"}}).WithValue("loggerMeta", &loggermeta.LoggerMeta{KeyVals:map[string]string{"resource":"status", "controller":"kvm-operator", "loop":"5", "event":"update", "object":"/apis/provider.giantswarm.io/v1alpha1/namespaces/default/kvmconfigs/ca59h", "version":"125941581"}}).WithValue("loggerMeta", &loggermeta.LoggerMeta{KeyVals:map[string]string{"object":"/apis/provider.giantswarm.io/v1alpha1/namespaces/default/kvmconfigs/ca59h", "version":"125941581", "resource":"status", "controller":"kvm-operator", "loop":"5", "event":"update"}}).WithValue("loggerMeta", &loggermeta.LoggerMeta{KeyVa...
```
With patch:
```
context.Background.WithValue("loggerMeta", &loggermeta.LoggerMeta{KeyVals:map[string]string{"controller":"kvm-operator-drainer", "loop":"987", "event":"update", "object":"/api/v1/namespaces/7to2f/pods/worker-seq5j-95c886dd6-wf9ns", "version":"147220892", "resource":"podv23"}})
```