### PR TITLE
Don't construct new context when updating existing one

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -542,8 +542,10 @@ func setLoggerCtxValue(ctx context.Context, key, value string) context.Context {
 	m, ok := loggermeta.FromContext(ctx)
 	if !ok {
 		m = loggermeta.New()
+		ctx = loggermeta.NewContext(ctx, m)
 	}
+
 	m.KeyVals[key] = value
 
-	return loggermeta.NewContext(ctx, m)
+	return ctx
 }

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -1,0 +1,66 @@
+package controller
+
+import (
+	"context"
+	"reflect"
+	"testing"
+)
+
+func Test_setLoggerCtxValue_doesnt_leak(t *testing.T) {
+	ctx := context.Background()
+
+	l := valueCtxLen(ctx)
+	expected := 0
+	if l != expected {
+		t.Fatalf("countValueContextLength(ctx) - expected %d, got %d", expected, l)
+	}
+
+	ctx = setLoggerCtxValue(ctx, "foo", "bar")
+	ctx = setLoggerCtxValue(ctx, "bar", "baz")
+	ctx = setLoggerCtxValue(ctx, "baz", "foo")
+
+	l = valueCtxLen(ctx)
+	expected = 1
+	if l != expected {
+		t.Fatalf("countValueContextLength(ctx) - expected %d, got %d", expected, l)
+	}
+}
+
+func valueCtxLen(ctx context.Context) int {
+	return countValueContextLength(0, ctx)
+}
+
+func countValueContextLength(i int, ctx interface{}) int {
+	if !isValueCtx(ctx) {
+		return i
+	}
+
+	v := reflect.ValueOf(ctx)
+
+	if v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+
+	v = v.FieldByName("Context")
+	i++
+
+	if v.IsValid() {
+		return countValueContextLength(i, v.Interface())
+	}
+
+	return i
+}
+
+func isValueCtx(ctx interface{}) bool {
+	t := reflect.TypeOf(ctx)
+
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+
+	if t.PkgPath() != "context" || t.Name() != "valueCtx" {
+		return false
+	}
+
+	return true
+}


### PR DESCRIPTION
Construction of new context when updating existing one creates a memory leak
because internal implementation of reflect.WithValue() uses reflect.valueCtx
that is essentially a linked list. Therefore construction of new context on
value setting effectively adds a new element to this list and therefore creates
a memory leak when called e.g. in loop.

With this change the new context is only created when existing context doesn't
contain loggermeta context value.

Towards https://github.com/giantswarm/giantswarm/issues/6416
Replaces https://github.com/giantswarm/operatorkit/pull/305