### PR TITLE
fix resource deletion

### DIFF
--- a/resource/k8s/configmapresource/create.go
+++ b/resource/k8s/configmapresource/create.go
@@ -37,7 +37,6 @@ func (r *Resource) newCreateChange(ctx context.Context, obj, currentState, desir
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
-
 	desiredConfigMaps, err := toConfigMaps(desiredState)
 	if err != nil {
 		return nil, microerror.Mask(err)

--- a/resource/k8s/configmapresource/delete.go
+++ b/resource/k8s/configmapresource/delete.go
@@ -33,7 +33,16 @@ func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange inte
 	return nil
 }
 
-func (r *Resource) newDeleteChange(ctx context.Context, obj, currentState, desiredState interface{}) ([]*corev1.ConfigMap, error) {
+func (r *Resource) newDeleteChangeForDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) ([]*corev1.ConfigMap, error) {
+	currentConfigMaps, err := toConfigMaps(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return currentConfigMaps, nil
+}
+
+func (r *Resource) newDeleteChangeForUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) ([]*corev1.ConfigMap, error) {
 	currentConfigMaps, err := toConfigMaps(currentState)
 	if err != nil {
 		return nil, microerror.Mask(err)

--- a/resource/k8s/configmapresource/delete.go
+++ b/resource/k8s/configmapresource/delete.go
@@ -27,7 +27,6 @@ func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange inte
 		} else {
 			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted ConfigMap %#q in namespace %#q", configMap.Name, configMap.Namespace))
 		}
-
 	}
 
 	return nil

--- a/resource/k8s/configmapresource/patch.go
+++ b/resource/k8s/configmapresource/patch.go
@@ -8,34 +8,26 @@ import (
 )
 
 func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
-	p, err := r.newPatch(ctx, obj, currentState, desiredState)
+	delete, err := r.newDeleteChangeForDeletePatch(ctx, obj, currentState, desiredState)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
 
-	return p, nil
+	patch := controller.NewPatch()
+	patch.SetDeleteChange(delete)
+
+	return patch, nil
 }
 
 func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
-	p, err := r.newPatch(ctx, obj, currentState, desiredState)
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
-
-	return p, nil
-}
-
-func (r *Resource) newPatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
 	create, err := r.newCreateChange(ctx, obj, currentState, desiredState)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
-
-	delete, err := r.newDeleteChange(ctx, obj, currentState, desiredState)
+	delete, err := r.newDeleteChangeForUpdatePatch(ctx, obj, currentState, desiredState)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
-
 	update, err := r.newUpdateChange(ctx, obj, currentState, desiredState)
 	if err != nil {
 		return nil, microerror.Mask(err)

--- a/resource/k8s/configmapresource/update.go
+++ b/resource/k8s/configmapresource/update.go
@@ -33,7 +33,6 @@ func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desir
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
-
 	desiredConfigMaps, err := toConfigMaps(desiredState)
 	if err != nil {
 		return nil, microerror.Mask(err)

--- a/resource/k8s/secretresource/create.go
+++ b/resource/k8s/secretresource/create.go
@@ -37,7 +37,6 @@ func (r *Resource) newCreateChange(ctx context.Context, obj, currentState, desir
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
-
 	desiredSecrets, err := toSecrets(desiredState)
 	if err != nil {
 		return nil, microerror.Mask(err)

--- a/resource/k8s/secretresource/delete.go
+++ b/resource/k8s/secretresource/delete.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/giantswarm/microerror"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -33,7 +33,16 @@ func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange inte
 	return nil
 }
 
-func (r *Resource) newDeleteChange(ctx context.Context, obj, currentState, desiredState interface{}) ([]*v1.Secret, error) {
+func (r *Resource) newDeleteChangeForDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) ([]*corev1.Secret, error) {
+	currentSecrets, err := toSecrets(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return currentSecrets, nil
+}
+
+func (r *Resource) newDeleteChangeForUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) ([]*corev1.Secret, error) {
 	currentSecrets, err := toSecrets(currentState)
 	if err != nil {
 		return nil, microerror.Mask(err)
@@ -43,7 +52,7 @@ func (r *Resource) newDeleteChange(ctx context.Context, obj, currentState, desir
 		return nil, microerror.Mask(err)
 	}
 
-	var secretsToDelete []*v1.Secret
+	var secretsToDelete []*corev1.Secret
 	{
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("computing Secrets to delete"))
 

--- a/resource/k8s/secretresource/delete.go
+++ b/resource/k8s/secretresource/delete.go
@@ -27,7 +27,6 @@ func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange inte
 		} else {
 			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted Secret %#q in namespace %#q", secret.Name, secret.Namespace))
 		}
-
 	}
 
 	return nil

--- a/resource/k8s/secretresource/patch.go
+++ b/resource/k8s/secretresource/patch.go
@@ -8,34 +8,26 @@ import (
 )
 
 func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
-	p, err := r.newPatch(ctx, obj, currentState, desiredState)
+	delete, err := r.newDeleteChangeForDeletePatch(ctx, obj, currentState, desiredState)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
 
-	return p, nil
+	patch := controller.NewPatch()
+	patch.SetDeleteChange(delete)
+
+	return patch, nil
 }
 
 func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
-	p, err := r.newPatch(ctx, obj, currentState, desiredState)
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
-
-	return p, nil
-}
-
-func (r *Resource) newPatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
 	create, err := r.newCreateChange(ctx, obj, currentState, desiredState)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
-
-	delete, err := r.newDeleteChange(ctx, obj, currentState, desiredState)
+	delete, err := r.newDeleteChangeForUpdatePatch(ctx, obj, currentState, desiredState)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
-
 	update, err := r.newUpdateChange(ctx, obj, currentState, desiredState)
 	if err != nil {
 		return nil, microerror.Mask(err)

--- a/resource/k8s/secretresource/update.go
+++ b/resource/k8s/secretresource/update.go
@@ -33,7 +33,6 @@ func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desir
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
-
 	desiredSecrets, err := toSecrets(desiredState)
 	if err != nil {
 		return nil, microerror.Mask(err)


### PR DESCRIPTION
Using the common resources I noticed deletion does not work as expected during delete events. Objects are not deleted. Checking the code we generate the same patches for update and delete events. This PR keeps the update patches as they are and I assume these are fine. We only change the delete patches as such that we simply delete what we get with the current state. 