### PR TITLE
move crud resource to resource package

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -23,6 +23,7 @@ import (
 	"github.com/giantswarm/operatorkit/controller/context/reconciliationcanceledcontext"
 	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
 	"github.com/giantswarm/operatorkit/informer"
+	"github.com/giantswarm/operatorkit/resource"
 )
 
 const (
@@ -495,7 +496,7 @@ func (c *Controller) resourceSet(obj interface{}) (*ResourceSet, error) {
 //         DeleteFunc:    deleteFunc,
 //     }
 //
-func ProcessDelete(ctx context.Context, obj interface{}, resources []Resource) error {
+func ProcessDelete(ctx context.Context, obj interface{}, resources []resource.Interface) error {
 	if len(resources) == 0 {
 		return microerror.Maskf(executionFailedError, "resources must not be empty")
 	}
@@ -536,7 +537,7 @@ func ProcessDelete(ctx context.Context, obj interface{}, resources []Resource) e
 //         UpdateFunc:    updateFunc,
 //     }
 //
-func ProcessUpdate(ctx context.Context, obj interface{}, resources []Resource) error {
+func ProcessUpdate(ctx context.Context, obj interface{}, resources []resource.Interface) error {
 	if len(resources) == 0 {
 		return microerror.Maskf(executionFailedError, "resources must not be empty")
 	}

--- a/controller/controller_cancel_crud_test.go
+++ b/controller/controller_cancel_crud_test.go
@@ -11,11 +11,12 @@ import (
 
 	"github.com/giantswarm/operatorkit/controller/context/reconciliationcanceledcontext"
 	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
+	"github.com/giantswarm/operatorkit/resource"
 )
 
 func Test_ProcessDelete_CRUD(t *testing.T) {
 	testCases := []struct {
-		Resources     []Resource
+		Resources     []resource.Interface
 		ExpectedOrder []string
 		ErrorMatcher  func(err error) bool
 	}{
@@ -29,7 +30,7 @@ func Test_ProcessDelete_CRUD(t *testing.T) {
 
 		// Test 1 ensures ProcessDelete calls EnsureDeleted method of the resource.
 		{
-			Resources: []Resource{
+			Resources: []resource.Interface{
 				newTestCRUDResource("r0"),
 			},
 			ExpectedOrder: []string{
@@ -46,7 +47,7 @@ func Test_ProcessDelete_CRUD(t *testing.T) {
 		// Test 2 ensures ProcessDelete executes all the resources in
 		// the expected order.
 		{
-			Resources: []Resource{
+			Resources: []resource.Interface{
 				newTestCRUDResource("r0"),
 				newTestCRUDResource("r1"),
 			},
@@ -71,7 +72,7 @@ func Test_ProcessDelete_CRUD(t *testing.T) {
 		// Test 3 ensures ProcessDelete executes resources in the
 		// expected order until the reconciliation gets canceled.
 		{
-			Resources: []Resource{
+			Resources: []resource.Interface{
 				newTestCRUDResource("r0"),
 				newTestCRUDResource("r1"),
 				newTestCRUDResource("r2").CancelReconciliationAt("GetDesiredState"),
@@ -101,7 +102,7 @@ func Test_ProcessDelete_CRUD(t *testing.T) {
 		// Test 4 ensures ProcessDelete executes next resource after
 		// resourcecanceledcontext is cancelled.
 		{
-			Resources: []Resource{
+			Resources: []resource.Interface{
 				newTestCRUDResource("r0").CancelResourceAt("ApplyDeleteChange"),
 				newTestCRUDResource("r1"),
 				newTestCRUDResource("r2").CancelResourceAt("GetDesiredState"),
@@ -166,7 +167,7 @@ func Test_ProcessDelete_CRUD(t *testing.T) {
 
 func Test_ProcessUpdate_CRUD(t *testing.T) {
 	testCases := []struct {
-		Resources     []Resource
+		Resources     []resource.Interface
 		ExpectedOrder []string
 		ErrorMatcher  func(err error) bool
 	}{
@@ -180,7 +181,7 @@ func Test_ProcessUpdate_CRUD(t *testing.T) {
 
 		// Test 1 ensures ProcessUpdate calls EnsureDeleted method of the resource.
 		{
-			Resources: []Resource{
+			Resources: []resource.Interface{
 				newTestCRUDResource("r0"),
 			},
 			ExpectedOrder: []string{
@@ -197,7 +198,7 @@ func Test_ProcessUpdate_CRUD(t *testing.T) {
 		// Test 2 ensures ProcessUpdate executes all the resources in
 		// the expected order.
 		{
-			Resources: []Resource{
+			Resources: []resource.Interface{
 				newTestCRUDResource("r0"),
 				newTestCRUDResource("r1"),
 			},
@@ -222,7 +223,7 @@ func Test_ProcessUpdate_CRUD(t *testing.T) {
 		// Test 3 ensures ProcessUpdate executes resources in the
 		// expected order until the reconciliation gets canceled.
 		{
-			Resources: []Resource{
+			Resources: []resource.Interface{
 				newTestCRUDResource("r0"),
 				newTestCRUDResource("r1"),
 				newTestCRUDResource("r2").CancelReconciliationAt("GetDesiredState"),
@@ -252,7 +253,7 @@ func Test_ProcessUpdate_CRUD(t *testing.T) {
 		// Test 4 ensures ProcessUpdate executes next resource after
 		// resourcecanceledcontext is cancelled.
 		{
-			Resources: []Resource{
+			Resources: []resource.Interface{
 				newTestCRUDResource("r0").CancelResourceAt("ApplyDeleteChange"),
 				newTestCRUDResource("r1"),
 				newTestCRUDResource("r2").CancelResourceAt("GetDesiredState"),

--- a/controller/controller_cancel_test.go
+++ b/controller/controller_cancel_test.go
@@ -7,11 +7,12 @@ import (
 
 	"github.com/giantswarm/operatorkit/controller/context/reconciliationcanceledcontext"
 	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
+	"github.com/giantswarm/operatorkit/resource"
 )
 
 func Test_ProcessDelete(t *testing.T) {
 	testCases := []struct {
-		Resources     []Resource
+		Resources     []resource.Interface
 		ExpectedOrder []string
 		ErrorMatcher  func(err error) bool
 	}{
@@ -25,7 +26,7 @@ func Test_ProcessDelete(t *testing.T) {
 
 		// Test 1 ensures ProcessDelete calls EnsureDeleted method of the resource.
 		{
-			Resources: []Resource{
+			Resources: []resource.Interface{
 				newTestResource("r0"),
 			},
 			ExpectedOrder: []string{
@@ -37,7 +38,7 @@ func Test_ProcessDelete(t *testing.T) {
 		// Test 2 ensures ProcessDelete executes all the resources in
 		// the expected order.
 		{
-			Resources: []Resource{
+			Resources: []resource.Interface{
 				newTestResource("r0"),
 				newTestResource("r1"),
 			},
@@ -51,7 +52,7 @@ func Test_ProcessDelete(t *testing.T) {
 		// Test 3 ensures ProcessDelete executes resources in the
 		// expected order until the reconciliation gets canceled.
 		{
-			Resources: []Resource{
+			Resources: []resource.Interface{
 				newTestResource("r0"),
 				newTestResource("r1"),
 				newTestResource("r2").SetReconcilationCancelledAt("EnsureDeleted"),
@@ -68,7 +69,7 @@ func Test_ProcessDelete(t *testing.T) {
 		// Test 4 ensures ProcessDelete executes next resource after
 		// resourcecanceledcontext is cancelled.
 		{
-			Resources: []Resource{
+			Resources: []resource.Interface{
 				newTestResource("r0"),
 				newTestResource("r1"),
 				newTestResource("r2").CancelResourceAt("EnsureDeleted"),
@@ -109,7 +110,7 @@ func Test_ProcessDelete(t *testing.T) {
 
 func Test_ProcessUpdate(t *testing.T) {
 	testCases := []struct {
-		Resources     []Resource
+		Resources     []resource.Interface
 		ExpectedOrder []string
 		ErrorMatcher  func(err error) bool
 	}{
@@ -123,7 +124,7 @@ func Test_ProcessUpdate(t *testing.T) {
 
 		// Test 1 ensures ProcessUpdate calls EnsureCreated method of the resource.
 		{
-			Resources: []Resource{
+			Resources: []resource.Interface{
 				newTestResource("r0"),
 			},
 			ExpectedOrder: []string{
@@ -135,7 +136,7 @@ func Test_ProcessUpdate(t *testing.T) {
 		// Test 2 ensures ProcessUpdate executes all resources in the
 		// expected order.
 		{
-			Resources: []Resource{
+			Resources: []resource.Interface{
 				newTestResource("r0"),
 				newTestResource("r1"),
 			},
@@ -149,7 +150,7 @@ func Test_ProcessUpdate(t *testing.T) {
 		// Test 3 ensures ProcessUpdate executes resources in the
 		// expected order until the reconciliation gets canceled.
 		{
-			Resources: []Resource{
+			Resources: []resource.Interface{
 				newTestResource("r0"),
 				newTestResource("r1"),
 				newTestResource("r2").SetReconcilationCancelledAt("EnsureCreated"),
@@ -166,7 +167,7 @@ func Test_ProcessUpdate(t *testing.T) {
 		// Test 4 ensures ProcessUpdate executes next resource after
 		// resourcecanceledcontext is cancelled.
 		{
-			Resources: []Resource{
+			Resources: []resource.Interface{
 				newTestResource("r0"),
 				newTestResource("r1"),
 				newTestResource("r2").CancelResourceAt("EnsureCreated"),

--- a/controller/crud_resource.go
+++ b/controller/crud_resource.go
@@ -1,3 +1,5 @@
+// NOTE the CRUD resource has moved to operatorkit/resource/crud. The code below
+// is DEPRECATED and only kept for backward compatibility.
 package controller
 
 import (

--- a/controller/crud_resource_ops.go
+++ b/controller/crud_resource_ops.go
@@ -1,3 +1,5 @@
+// NOTE the CRUD resource has moved to operatorkit/resource/crud. The code below
+// is DEPRECATED and only kept for backward compatibility.
 package controller
 
 import "context"

--- a/controller/crud_resource_patch_dispatch_test.go
+++ b/controller/crud_resource_patch_dispatch_test.go
@@ -1,3 +1,5 @@
+// NOTE the CRUD resource has moved to operatorkit/resource/crud. The code below
+// is DEPRECATED and only kept for backward compatibility.
 package controller
 
 import (

--- a/controller/integration/test/controlflow/controlflow_test.go
+++ b/controller/integration/test/controlflow/controlflow_test.go
@@ -14,10 +14,10 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/operatorkit/controller"
 	"github.com/giantswarm/operatorkit/controller/integration/testresource"
 	"github.com/giantswarm/operatorkit/controller/integration/wrapper"
 	"github.com/giantswarm/operatorkit/controller/integration/wrapper/drainerconfig"
+	"github.com/giantswarm/operatorkit/resource"
 )
 
 const (
@@ -244,13 +244,11 @@ func Test_Finalizer_Integration_Controlflow(t *testing.T) {
 	}
 }
 
-func newHarness(namespace string, controllerName string, resource *testresource.Resource) (*drainerconfig.Wrapper, error) {
-	resources := []controller.Resource{
-		controller.Resource(resource),
-	}
-
+func newHarness(namespace string, controllerName string, r *testresource.Resource) (*drainerconfig.Wrapper, error) {
 	c := drainerconfig.Config{
-		Resources: resources,
+		Resources: []resource.Interface{
+			r,
+		},
 
 		Name:      controllerName,
 		Namespace: namespace,

--- a/controller/integration/test/error/error_test.go
+++ b/controller/integration/test/error/error_test.go
@@ -13,9 +13,9 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/operatorkit/controller"
 	"github.com/giantswarm/operatorkit/controller/integration/testresource"
 	"github.com/giantswarm/operatorkit/controller/integration/wrapper/drainerconfig"
+	"github.com/giantswarm/operatorkit/resource"
 )
 
 const (
@@ -65,7 +65,7 @@ func Test_Controller_Integration_Error(t *testing.T) {
 		}
 	}
 
-	resources := []controller.Resource{
+	resources := []resource.Interface{
 		rA,
 		rB,
 	}

--- a/controller/integration/test/parallel/parallel_test.go
+++ b/controller/integration/test/parallel/parallel_test.go
@@ -16,9 +16,9 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/operatorkit/controller"
 	"github.com/giantswarm/operatorkit/controller/integration/testresource"
 	"github.com/giantswarm/operatorkit/controller/integration/wrapper/drainerconfig"
+	"github.com/giantswarm/operatorkit/resource"
 )
 
 const (
@@ -381,13 +381,11 @@ func Test_Finalizer_Integration_Parallel(t *testing.T) {
 	}
 }
 
-func newHarness(namespace string, controllerName string, resource *testresource.Resource) (*drainerconfig.Wrapper, error) {
-	resources := []controller.Resource{
-		controller.Resource(resource),
-	}
-
+func newHarness(namespace string, controllerName string, r *testresource.Resource) (*drainerconfig.Wrapper, error) {
 	c := drainerconfig.Config{
-		Resources: resources,
+		Resources: []resource.Interface{
+			r,
+		},
 
 		Name:      controllerName,
 		Namespace: namespace,

--- a/controller/integration/test/reconciliation/reconciliation_test.go
+++ b/controller/integration/test/reconciliation/reconciliation_test.go
@@ -11,9 +11,9 @@ import (
 	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
 	"github.com/giantswarm/backoff"
 	"github.com/giantswarm/microerror"
-	"github.com/giantswarm/operatorkit/controller"
 	"github.com/giantswarm/operatorkit/controller/integration/testresource"
 	"github.com/giantswarm/operatorkit/controller/integration/wrapper/drainerconfig"
+	"github.com/giantswarm/operatorkit/resource"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -33,22 +33,20 @@ func Test_Finalizer_Integration_Reconciliation(t *testing.T) {
 
 	ctx := context.Background()
 
-	var tr *testresource.Resource
+	var r *testresource.Resource
 	{
 		c := testresource.Config{}
 
-		tr, err = testresource.New(c)
+		r, err = testresource.New(c)
 		if err != nil {
 			t.Fatal("expected", nil, "got", err)
 		}
 	}
 
-	resources := []controller.Resource{
-		controller.Resource(tr),
-	}
-
 	c := drainerconfig.Config{
-		Resources: resources,
+		Resources: []resource.Interface{
+			r,
+		},
 
 		Name:      operatorName,
 		Namespace: testNamespace,
@@ -140,11 +138,11 @@ func Test_Finalizer_Integration_Reconciliation(t *testing.T) {
 	//
 	{
 		o := func() error {
-			if tr.CreateCount() != 4 {
-				return microerror.Maskf(countMismatchError, "EnsureCreated was hit %v times, want %v", tr.CreateCount(), 4)
+			if r.CreateCount() != 4 {
+				return microerror.Maskf(countMismatchError, "EnsureCreated was hit %v times, want %v", r.CreateCount(), 4)
 			}
-			if tr.DeleteCount() != 0 {
-				return microerror.Maskf(countMismatchError, "EnsureDeleted was hit %v times, want %v", tr.DeleteCount(), 0)
+			if r.DeleteCount() != 0 {
+				return microerror.Maskf(countMismatchError, "EnsureDeleted was hit %v times, want %v", r.DeleteCount(), 0)
 			}
 			return nil
 		}
@@ -194,11 +192,11 @@ func Test_Finalizer_Integration_Reconciliation(t *testing.T) {
 	// 		EnsureCreated: 4, EnsureDeleted: 1
 	{
 		o := func() error {
-			if tr.CreateCount() != 4 {
-				return microerror.Maskf(countMismatchError, "EnsureCreated was hit %v times, want %v", tr.CreateCount(), 4)
+			if r.CreateCount() != 4 {
+				return microerror.Maskf(countMismatchError, "EnsureCreated was hit %v times, want %v", r.CreateCount(), 4)
 			}
-			if tr.DeleteCount() != 1 {
-				return microerror.Maskf(countMismatchError, "EnsureDeleted was hit %v times, want %v", tr.DeleteCount(), 1)
+			if r.DeleteCount() != 1 {
+				return microerror.Maskf(countMismatchError, "EnsureDeleted was hit %v times, want %v", r.DeleteCount(), 1)
 			}
 			return nil
 		}

--- a/controller/integration/test/statusupdate/status_update_test.go
+++ b/controller/integration/test/statusupdate/status_update_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/giantswarm/operatorkit/controller"
 	"github.com/giantswarm/operatorkit/controller/integration/wrapper/drainerconfig"
+	"github.com/giantswarm/operatorkit/resource"
 )
 
 const (
@@ -50,7 +51,7 @@ func Test_Finalizer_Integration_StatusUpdate(t *testing.T) {
 	var drainerConfigWrapper *drainerconfig.Wrapper
 	{
 		c := drainerconfig.Config{
-			Resources: []controller.Resource{
+			Resources: []resource.Interface{
 				r,
 			},
 

--- a/controller/integration/testresourceset/resource_set.go
+++ b/controller/integration/testresourceset/resource_set.go
@@ -6,24 +6,24 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/giantswarm/operatorkit/controller"
-
 	"github.com/giantswarm/operatorkit/controller/integration/testresource"
+	"github.com/giantswarm/operatorkit/resource"
 )
 
 type Config struct {
 	K8sClient kubernetes.Interface
 	Logger    micrologger.Logger
-	Resources []controller.Resource
+	Resources []resource.Interface
 
 	ProjectName string
 }
 
 func New(config Config) (*controller.ResourceSet, error) {
 	var err error
-	var resources []controller.Resource
+	var resources []resource.Interface
 
 	if len(config.Resources) == 0 {
-		var tr controller.Resource
+		var tr resource.Interface
 		{
 			c := testresource.Config{}
 
@@ -33,7 +33,7 @@ func New(config Config) (*controller.ResourceSet, error) {
 			}
 		}
 
-		resources = []controller.Resource{
+		resources = []resource.Interface{
 			tr,
 		}
 	} else {

--- a/controller/integration/wrapper/configmap/wrapper.go
+++ b/controller/integration/wrapper/configmap/wrapper.go
@@ -16,10 +16,11 @@ import (
 	"github.com/giantswarm/operatorkit/controller"
 	"github.com/giantswarm/operatorkit/controller/integration/testresourceset"
 	"github.com/giantswarm/operatorkit/informer"
+	"github.com/giantswarm/operatorkit/resource"
 )
 
 type Config struct {
-	Resources []controller.Resource
+	Resources []resource.Interface
 
 	Name      string
 	Namespace string

--- a/controller/integration/wrapper/drainerconfig/wrapper.go
+++ b/controller/integration/wrapper/drainerconfig/wrapper.go
@@ -19,10 +19,11 @@ import (
 	"github.com/giantswarm/operatorkit/controller"
 	"github.com/giantswarm/operatorkit/controller/integration/testresourceset"
 	"github.com/giantswarm/operatorkit/informer"
+	"github.com/giantswarm/operatorkit/resource"
 )
 
 type Config struct {
-	Resources []controller.Resource
+	Resources []resource.Interface
 
 	Name      string
 	Namespace string

--- a/controller/patch.go
+++ b/controller/patch.go
@@ -1,3 +1,5 @@
+// NOTE the CRUD resource has moved to operatorkit/resource/crud. The code below
+// is DEPRECATED and only kept for backward compatibility.
 package controller
 
 type patchType string

--- a/controller/patch_no_panic_test.go
+++ b/controller/patch_no_panic_test.go
@@ -3,12 +3,14 @@ package controller
 import (
 	"context"
 	"testing"
+
+	"github.com/giantswarm/operatorkit/resource"
 )
 
 func Test_Controller_Resource_PatchNoPanic(t *testing.T) {
 	testCases := []struct {
-		ProcessMethod func(ctx context.Context, obj interface{}, rs []Resource) error
-		Resources     []Resource
+		ProcessMethod func(ctx context.Context, obj interface{}, rs []resource.Interface) error
+		Resources     []resource.Interface
 		ErrorMatcher  func(err error) bool
 	}{
 		// Test 0 ensures ProcessDelete returns an error in case no resources are
@@ -23,7 +25,7 @@ func Test_Controller_Resource_PatchNoPanic(t *testing.T) {
 		// resource.
 		{
 			ProcessMethod: ProcessDelete,
-			Resources: []Resource{
+			Resources: []resource.Interface{
 				&testResourcePatchNoPanic{},
 			},
 			ErrorMatcher: nil,
@@ -32,7 +34,7 @@ func Test_Controller_Resource_PatchNoPanic(t *testing.T) {
 		// Test 2 ensures ProcessDelete does not panic when executing two resources.
 		{
 			ProcessMethod: ProcessDelete,
-			Resources: []Resource{
+			Resources: []resource.Interface{
 				&testResourcePatchNoPanic{},
 				&testResourcePatchNoPanic{},
 			},
@@ -51,7 +53,7 @@ func Test_Controller_Resource_PatchNoPanic(t *testing.T) {
 		// resource.
 		{
 			ProcessMethod: ProcessUpdate,
-			Resources: []Resource{
+			Resources: []resource.Interface{
 				&testResourcePatchNoPanic{},
 			},
 			ErrorMatcher: nil,
@@ -60,7 +62,7 @@ func Test_Controller_Resource_PatchNoPanic(t *testing.T) {
 		// Test 5 ensures ProcessUpdate does not panic when executing two resources.
 		{
 			ProcessMethod: ProcessUpdate,
-			Resources: []Resource{
+			Resources: []resource.Interface{
 				&testResourcePatchNoPanic{},
 				&testResourcePatchNoPanic{},
 			},

--- a/controller/resource_set.go
+++ b/controller/resource_set.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/giantswarm/operatorkit/controller/context/finalizerskeptcontext"
 	"github.com/giantswarm/operatorkit/controller/context/updateallowedcontext"
+	"github.com/giantswarm/operatorkit/resource"
 )
 
 type ResourceSetConfig struct {
@@ -26,14 +27,14 @@ type ResourceSetConfig struct {
 	// Resources is the list of controller resources being executed on runtime
 	// object reconciliation if Handles returns true when asked by the
 	// controller. Resources are executed in given order.
-	Resources []Resource
+	Resources []resource.Interface
 }
 
 type ResourceSet struct {
 	handles   func(obj interface{}) bool
 	initCtx   func(ctx context.Context, obj interface{}) (context.Context, error)
 	logger    micrologger.Logger
-	resources []Resource
+	resources []resource.Interface
 }
 
 func NewResourceSet(c ResourceSetConfig) (*ResourceSet, error) {
@@ -79,6 +80,6 @@ func (r *ResourceSet) Handles(obj interface{}) bool {
 	return r.handles(obj)
 }
 
-func (r *ResourceSet) Resources() []Resource {
+func (r *ResourceSet) Resources() []resource.Interface {
 	return r.resources
 }

--- a/controller/spec.go
+++ b/controller/spec.go
@@ -1,3 +1,5 @@
+// NOTE the CRUD resource has moved to operatorkit/resource/crud. The code below
+// is DEPRECATED and only kept for backward compatibility.
 package controller
 
 import "context"

--- a/example/memcached-operator/controller/memcached.go
+++ b/example/memcached-operator/controller/memcached.go
@@ -9,9 +9,10 @@ import (
 
 	"github.com/giantswarm/operatorkit/client/k8scrdclient"
 	"github.com/giantswarm/operatorkit/controller"
-	"github.com/giantswarm/operatorkit/example/memcached-operator/controller/resource"
+	controllerresource "github.com/giantswarm/operatorkit/example/memcached-operator/controller/resource"
 	"github.com/giantswarm/operatorkit/example/memcached-operator/logger"
 	"github.com/giantswarm/operatorkit/informer"
+	"github.com/giantswarm/operatorkit/resource"
 )
 
 const name = "memcached-operator"
@@ -38,29 +39,29 @@ func NewMemcached(config Config) (*Memcached, error) {
 		watcher    = config.G8sClient.ExampleV1alpha1().MemcachedConfigs("")
 	)
 
-	var deploymentsResource controller.Resource
+	var deploymentsResource resource.Interface
 	{
-		c := resource.DeploymentsConfig{
+		c := controllerresource.DeploymentsConfig{
 			K8sClient: config.K8sClient,
 		}
 
-		deploymentsResource, err = resource.NewDeployments(c)
+		deploymentsResource, err = controllerresource.NewDeployments(c)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
 	}
 
-	var servicesResource controller.Resource
+	var servicesResource resource.Interface
 	{
-		c := resource.ServicesConfig{}
+		c := controllerresource.ServicesConfig{}
 
-		servicesResource, err = resource.NewServices(c)
+		servicesResource, err = controllerresource.NewServices(c)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
 	}
 
-	resources := []controller.Resource{
+	resources := []resource.Interface{
 		deploymentsResource,
 		servicesResource,
 	}
@@ -83,7 +84,6 @@ func NewMemcached(config Config) (*Memcached, error) {
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
-
 	}
 
 	// resourceSets is used in more complex operators that support multiple

--- a/example/memcached-operator/controller/simple_resource_router.go
+++ b/example/memcached-operator/controller/simple_resource_router.go
@@ -5,11 +5,12 @@ import (
 
 	"github.com/giantswarm/operatorkit/controller"
 	"github.com/giantswarm/operatorkit/example/memcached-operator/logger"
+	"github.com/giantswarm/operatorkit/resource"
 )
 
 // newSimpleResourceSets creates a list if resource sets which handles all
 // reconciled objects. In this case with only a single resource set.
-func newSimpleResourceSets(resources []controller.Resource) ([]*controller.ResourceSet, error) {
+func newSimpleResourceSets(resources []resource.Interface) ([]*controller.ResourceSet, error) {
 	var err error
 
 	var set *controller.ResourceSet

--- a/resource/crud/error.go
+++ b/resource/crud/error.go
@@ -1,0 +1,14 @@
+package crud
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/resource/crud/patch.go
+++ b/resource/crud/patch.go
@@ -1,0 +1,52 @@
+package crud
+
+type patchType string
+
+const (
+	patchCreate patchType = "create"
+	patchDelete patchType = "delete"
+	patchUpdate patchType = "update"
+)
+
+// Patch is a set of information required in order to reconcile the current
+// state towards the desired state. Patch is split into three parts: create,
+// delete and update changes. The parts are passed as arguments to the CRUD
+// Resource's ApplyCreateChange, ApplyDeleteChange and ApplyUpdateChange
+// functions respectively. Patch changes are guaranteed to be applied in that
+// order (i.e. create, update, delete).
+type Patch struct {
+	data map[patchType]interface{}
+}
+
+func NewPatch() *Patch {
+	return &Patch{
+		data: make(map[patchType]interface{}, 3),
+	}
+}
+
+func (p *Patch) SetCreateChange(create interface{}) {
+	p.data[patchCreate] = create
+}
+
+func (p *Patch) SetDeleteChange(delete interface{}) {
+	p.data[patchDelete] = delete
+}
+
+func (p *Patch) SetUpdateChange(update interface{}) {
+	p.data[patchUpdate] = update
+}
+
+func (p *Patch) getCreateChange() (interface{}, bool) {
+	create, ok := p.data[patchCreate]
+	return create, ok
+}
+
+func (p *Patch) getDeleteChange() (interface{}, bool) {
+	delete, ok := p.data[patchDelete]
+	return delete, ok
+}
+
+func (p *Patch) getUpdateChange() (interface{}, bool) {
+	update, ok := p.data[patchUpdate]
+	return update, ok
+}

--- a/resource/crud/resource.go
+++ b/resource/crud/resource.go
@@ -1,0 +1,329 @@
+package crud
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/micrologger/loggermeta"
+
+	"github.com/giantswarm/operatorkit/controller/context/reconciliationcanceledcontext"
+	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
+)
+
+type ResourceConfig struct {
+	// CRUD is any CRUD Resource implementation wrapped and properly executed by
+	// Resource.
+	CRUD   Interface
+	Logger micrologger.Logger
+}
+
+// Resource wraps Interface and allows the implemention of complex CRUD
+// Resrouces in a structured way. The usual control flow primitives like
+// canceling the resource itself or canceling the whole reconciliation loop are
+// available. Further benefits are dedicated metrics for the several CRUD
+// Resource steps defined by Interface when wrapped by the metricsresource
+// package.
+type Resource struct {
+	crud   Interface
+	logger micrologger.Logger
+}
+
+func NewResource(config ResourceConfig) (*Resource, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.CRUD == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.CRUD must not be empty", config)
+	}
+	if config.CRUD.Name() == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.CRUD.Name() must not be empty", config)
+	}
+
+	r := &Resource{
+		crud:   config.CRUD,
+		logger: config.Logger,
+	}
+
+	return r, nil
+}
+
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	var err error
+
+	var currentState interface{}
+	{
+		if reconciliationcanceledcontext.IsCanceled(ctx) {
+			return nil
+		}
+		if resourcecanceledcontext.IsCanceled(ctx) {
+			return nil
+		}
+
+		meta, ok := loggermeta.FromContext(ctx)
+		if ok {
+			meta.KeyVals["function"] = "GetCurrentState"
+			defer delete(meta.KeyVals, "function")
+		}
+		currentState, err = r.crud.GetCurrentState(ctx, obj)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	var desiredState interface{}
+	{
+		if reconciliationcanceledcontext.IsCanceled(ctx) {
+			return nil
+		}
+		if resourcecanceledcontext.IsCanceled(ctx) {
+			return nil
+		}
+
+		meta, ok := loggermeta.FromContext(ctx)
+		if ok {
+			meta.KeyVals["function"] = "GetDesiredState"
+			defer delete(meta.KeyVals, "function")
+		}
+		desiredState, err = r.crud.GetDesiredState(ctx, obj)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	var patch *Patch
+	{
+		if reconciliationcanceledcontext.IsCanceled(ctx) {
+			return nil
+		}
+		if resourcecanceledcontext.IsCanceled(ctx) {
+			return nil
+		}
+
+		meta, ok := loggermeta.FromContext(ctx)
+		if ok {
+			meta.KeyVals["function"] = "NewUpdatePatch"
+			defer delete(meta.KeyVals, "function")
+		}
+		patch, err = r.crud.NewUpdatePatch(ctx, obj, currentState, desiredState)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	{
+		if reconciliationcanceledcontext.IsCanceled(ctx) {
+			return nil
+		}
+		if resourcecanceledcontext.IsCanceled(ctx) {
+			return nil
+		}
+
+		if patch != nil {
+			createState, ok := patch.getCreateChange()
+			if ok {
+				meta, ok := loggermeta.FromContext(ctx)
+				if ok {
+					meta.KeyVals["function"] = "ApplyCreateChange"
+					defer delete(meta.KeyVals, "function")
+				}
+				err := r.crud.ApplyCreateChange(ctx, obj, createState)
+				if err != nil {
+					return microerror.Mask(err)
+				}
+			}
+		}
+	}
+
+	{
+		if reconciliationcanceledcontext.IsCanceled(ctx) {
+			return nil
+		}
+		if resourcecanceledcontext.IsCanceled(ctx) {
+			return nil
+		}
+
+		if patch != nil {
+			deleteState, ok := patch.getDeleteChange()
+			if ok {
+				meta, ok := loggermeta.FromContext(ctx)
+				if ok {
+					meta.KeyVals["function"] = "ApplyDeleteChange"
+					defer delete(meta.KeyVals, "function")
+				}
+				err := r.crud.ApplyDeleteChange(ctx, obj, deleteState)
+				if err != nil {
+					return microerror.Mask(err)
+				}
+			}
+		}
+	}
+
+	{
+		if reconciliationcanceledcontext.IsCanceled(ctx) {
+			return nil
+		}
+		if resourcecanceledcontext.IsCanceled(ctx) {
+			return nil
+		}
+
+		if patch != nil {
+			updateState, ok := patch.getUpdateChange()
+			if ok {
+				meta, ok := loggermeta.FromContext(ctx)
+				if ok {
+					meta.KeyVals["function"] = "ApplyUpdateChange"
+					defer delete(meta.KeyVals, "function")
+				}
+				err := r.crud.ApplyUpdateChange(ctx, obj, updateState)
+				if err != nil {
+					return microerror.Mask(err)
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	var err error
+
+	var currentState interface{}
+	{
+		if reconciliationcanceledcontext.IsCanceled(ctx) {
+			return nil
+		}
+		if resourcecanceledcontext.IsCanceled(ctx) {
+			return nil
+		}
+
+		meta, ok := loggermeta.FromContext(ctx)
+		if ok {
+			meta.KeyVals["function"] = "GetCurrentState"
+			defer delete(meta.KeyVals, "function")
+		}
+		currentState, err = r.crud.GetCurrentState(ctx, obj)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	var desiredState interface{}
+	{
+		if reconciliationcanceledcontext.IsCanceled(ctx) {
+			return nil
+		}
+		if resourcecanceledcontext.IsCanceled(ctx) {
+			return nil
+		}
+
+		meta, ok := loggermeta.FromContext(ctx)
+		if ok {
+			meta.KeyVals["function"] = "GetDesiredState"
+			defer delete(meta.KeyVals, "function")
+		}
+		desiredState, err = r.crud.GetDesiredState(ctx, obj)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	var patch *Patch
+	{
+		if reconciliationcanceledcontext.IsCanceled(ctx) {
+			return nil
+		}
+		if resourcecanceledcontext.IsCanceled(ctx) {
+			return nil
+		}
+
+		meta, ok := loggermeta.FromContext(ctx)
+		if ok {
+			meta.KeyVals["function"] = "NewDeletePatch"
+			defer delete(meta.KeyVals, "function")
+		}
+		patch, err = r.crud.NewDeletePatch(ctx, obj, currentState, desiredState)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	{
+		if reconciliationcanceledcontext.IsCanceled(ctx) {
+			return nil
+		}
+		if resourcecanceledcontext.IsCanceled(ctx) {
+			return nil
+		}
+
+		if patch != nil {
+			createChange, ok := patch.getCreateChange()
+			if ok {
+				meta, ok := loggermeta.FromContext(ctx)
+				if ok {
+					meta.KeyVals["function"] = "ApplyCreateChange"
+					defer delete(meta.KeyVals, "function")
+				}
+				err := r.crud.ApplyCreateChange(ctx, obj, createChange)
+				if err != nil {
+					return microerror.Mask(err)
+				}
+			}
+		}
+	}
+
+	{
+		if reconciliationcanceledcontext.IsCanceled(ctx) {
+			return nil
+		}
+		if resourcecanceledcontext.IsCanceled(ctx) {
+			return nil
+		}
+
+		if patch != nil {
+			deleteChange, ok := patch.getDeleteChange()
+			if ok {
+				meta, ok := loggermeta.FromContext(ctx)
+				if ok {
+					meta.KeyVals["function"] = "ApplyDeleteChange"
+					defer delete(meta.KeyVals, "function")
+				}
+				err := r.crud.ApplyDeleteChange(ctx, obj, deleteChange)
+				if err != nil {
+					return microerror.Mask(err)
+				}
+			}
+		}
+	}
+
+	{
+		if reconciliationcanceledcontext.IsCanceled(ctx) {
+			return nil
+		}
+		if resourcecanceledcontext.IsCanceled(ctx) {
+			return nil
+		}
+
+		if patch != nil {
+			updateChange, ok := patch.getUpdateChange()
+			if ok {
+				meta, ok := loggermeta.FromContext(ctx)
+				if ok {
+					meta.KeyVals["function"] = "ApplyUpdateChange"
+					defer delete(meta.KeyVals, "function")
+				}
+				err := r.crud.ApplyUpdateChange(ctx, obj, updateChange)
+				if err != nil {
+					return microerror.Mask(err)
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func (r *Resource) Name() string {
+	return r.crud.Name()
+}

--- a/resource/crud/resource_test.go
+++ b/resource/crud/resource_test.go
@@ -1,0 +1,179 @@
+package crud
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/giantswarm/micrologger/microloggertest"
+
+	"github.com/giantswarm/operatorkit/resource"
+)
+
+func Test_Resource_CRUD_Interface(t *testing.T) {
+	var r resource.Interface
+	r = &Resource{}
+	_ = fmt.Sprintf("%#v", r)
+}
+
+func Test_Resource_CRUD_PatchDispatch(t *testing.T) {
+	testCases := []struct {
+		CRUD Interface
+	}{
+		// Case 0
+		{
+			CRUD: &testCRUDResourceOpsPatchDispatch{
+				Patch: func() *Patch {
+					return nil
+				}(),
+			},
+		},
+
+		// Case 1
+		{
+			CRUD: &testCRUDResourceOpsPatchDispatch{
+				Patch: func() *Patch {
+					p := NewPatch()
+
+					p.SetCreateChange(true)
+
+					return p
+				}(),
+			},
+		},
+
+		// Case 2
+		{
+			CRUD: &testCRUDResourceOpsPatchDispatch{
+				Patch: func() *Patch {
+					p := NewPatch()
+
+					p.SetDeleteChange(true)
+
+					return p
+				}(),
+			},
+		},
+
+		// Case 3
+		{
+			CRUD: &testCRUDResourceOpsPatchDispatch{
+				Patch: func() *Patch {
+					p := NewPatch()
+
+					p.SetDeleteChange(true)
+
+					return p
+				}(),
+			},
+		},
+
+		// Case 4
+		{
+			CRUD: &testCRUDResourceOpsPatchDispatch{
+				Patch: func() *Patch {
+					p := NewPatch()
+
+					p.SetDeleteChange(true)
+					p.SetUpdateChange(true)
+
+					return p
+				}(),
+			},
+		},
+
+		// Case 5
+		{
+			CRUD: &testCRUDResourceOpsPatchDispatch{
+				Patch: func() *Patch {
+					p := NewPatch()
+
+					p.SetCreateChange(true)
+					p.SetDeleteChange(true)
+					p.SetUpdateChange(true)
+
+					return p
+				}(),
+			},
+		},
+	}
+
+	for i, tc := range testCases {
+		c := ResourceConfig{
+			CRUD:   tc.CRUD,
+			Logger: microloggertest.New(),
+		}
+
+		r, err := NewResource(c)
+		if err != nil {
+			t.Fatalf("test %d: unexpected NewCRUDResource error = %#v", i, err)
+		}
+
+		err = r.EnsureCreated(context.Background(), nil)
+		if err != nil {
+			t.Fatalf("test %d: unexpected EnsureCreated error = %#v", i, err)
+		}
+
+		err = r.EnsureDeleted(context.Background(), nil)
+		if err != nil {
+			t.Fatalf("test %d: unexpected EnsureDeleted error = %#v", i, err)
+		}
+	}
+}
+
+type testCRUDResourceOpsPatchDispatch struct {
+	Patch *Patch
+}
+
+func (r *testCRUDResourceOpsPatchDispatch) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
+	return nil, nil
+}
+
+func (r *testCRUDResourceOpsPatchDispatch) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {
+	return nil, nil
+}
+
+func (r *testCRUDResourceOpsPatchDispatch) NewUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*Patch, error) {
+	return r.Patch, nil
+}
+
+func (r *testCRUDResourceOpsPatchDispatch) NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*Patch, error) {
+	return r.Patch, nil
+}
+
+func (r *testCRUDResourceOpsPatchDispatch) Name() string {
+	return "testCRUDResourceOpsPatchDispatch"
+}
+
+func (r *testCRUDResourceOpsPatchDispatch) ApplyCreateChange(ctx context.Context, obj, createState interface{}) error {
+	createChange, ok := r.Patch.getCreateChange()
+	if ok {
+		if createChange != createState {
+			panic(fmt.Sprintf("expected '%s' got '%s'", createChange, createState))
+		}
+	}
+
+	return nil
+}
+
+func (r *testCRUDResourceOpsPatchDispatch) ApplyDeleteChange(ctx context.Context, obj, deleteState interface{}) error {
+	deleteChange, ok := r.Patch.getDeleteChange()
+	if ok {
+		if deleteChange != deleteState {
+			panic(fmt.Sprintf("expected '%s' got '%s'", deleteChange, deleteState))
+		}
+	}
+
+	return nil
+}
+
+func (r *testCRUDResourceOpsPatchDispatch) ApplyUpdateChange(ctx context.Context, obj, updateState interface{}) error {
+	updateChange, ok := r.Patch.getUpdateChange()
+	if ok {
+		if updateChange != updateState {
+			panic(fmt.Sprintf("expected '%s' got '%s'", updateChange, updateState))
+		}
+	}
+
+	return nil
+}

--- a/resource/crud/spec.go
+++ b/resource/crud/spec.go
@@ -1,0 +1,85 @@
+package crud
+
+import "context"
+
+// Interface provides set of building blocks of a CRUD Resource business logic
+// being reconciled when observing runtime objects. The interface provides a
+// guideline for an easier way to follow the rather complex intentions of
+// operators' reconciliation in general.
+type Interface interface {
+	// Name returns the resource's name used for identification.
+	Name() string
+
+	// GetCurrentState receives the custom object observed during custom
+	// resource watches. Its purpose is to return the current state of the
+	// resources being managed by the operator. This can e.g. be some
+	// actual data within a configmap as provided by the Kubernetes API.
+	// This is not limited to Kubernetes resources though. Another example
+	// would be to fetch and return information about Flannel bridges.
+	//
+	// NOTE GetCurrentState is called on create, delete and update events. When
+	// called on create and delete events the provided custom object will be the
+	// custom object currently known to the informer. On update events the
+	// informer knows about the old and the new custom object. GetCurrentState
+	// then receives the new custom object to be able to consume the current state
+	// of a system.
+	GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error)
+	// GetDesiredState receives the custom object observed during custom
+	// resource watches. Its purpose is to return the desired state of the
+	// resources being managed by the operator. The desired state should
+	// always be able to be made up using the information provided by the
+	// custom object. This can e.g. be some data within a configmap, how it
+	// should be provided by the Kubernetes API. This is not limited to
+	// Kubernetes resources though. Another example would be to make up and
+	// return information about Flannel bridges, how they should look like
+	// on a server host.
+	//
+	// NOTE GetDesiredState is called on create, delete and update events.
+	// When called on create events the provided custom object will be the
+	// custom object currently known to the informer. On update events the
+	// informer knows about the old and the new custom object.
+	// GetDesiredState then receives the new custom object to be able to
+	// compute the desired state of a system.
+	GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error)
+
+	// NewUpdatePatch is called upon observed custom object change. It receives
+	// the observed custom object, the current state as provided by
+	// GetCurrentState and the desired state as provided by
+	// GetDesiredState. NewUpdatePatch analyses the current and desired
+	// state and returns the patch to be applied by Create, Delete, and
+	// Update functions. ApplyCreateChange, ApplyDeleteChange, and
+	// ApplyUpdateChange are called only when the corresponding patch part
+	// was created.
+	NewUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*Patch, error)
+	// NewDeletePatch is called upon observed custom object deletion. It
+	// receives the deleted custom object, the current state as provided by
+	// GetCurrentState and the desired state as provided by
+	// GetDesiredState. NewDeletePatch analyses the current and desired
+	// state returns the patch to be applied by Create, Delete, and Update
+	// functions. ApplyCreateChange, ApplyDeleteChange, and
+	// ApplyUpdateChange are called only when the corresponding patch part
+	// was created.
+	NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*Patch, error)
+
+	// ApplyCreateChange receives the new custom object observed during
+	// custom resource watches. It also receives the create portion of the
+	// Patch provided by NewUpdatePatch or NewDeletePatch.
+	// ApplyCreateChange only has to create resources based on its provided
+	// input. All other reconciliation logic and state transformation is
+	// already done at this point of the reconciliation loop.
+	ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error
+	// ApplyDeleteChange receives the new custom object observed during
+	// custom resource watches. It also receives the delete portion of the
+	// Patch provided by NewUpdatePatch or NewDeletePatch.
+	// ApplyDeleteChange only has to delete resources based on its provided
+	// input. All other reconciliation logic and state transformation is
+	// already done at this point of the reconciliation loop.
+	ApplyDeleteChange(ctx context.Context, obj, deleteChange interface{}) error
+	// ApplyUpdateChange receives the new custom object observed during
+	// custom resource watches. It also receives the update portion of the
+	// Patch provided by NewUpdatePatch or NewDeletePatch.
+	// ApplyUpdateChange has to update resources based on its provided
+	// input. All other reconciliation logic and state transformation is
+	// already done at this point of the reconciliation loop.
+	ApplyUpdateChange(ctx context.Context, obj, updateChange interface{}) error
+}

--- a/resource/spec.go
+++ b/resource/spec.go
@@ -1,0 +1,25 @@
+package resource
+
+import "context"
+
+// Interface defines the building blocks of an operator's reconciliation logic.
+// Note there can be multiple Resources reconciling the same object in a chain.
+// In that case they are guaranteed to be executed in order one after another.
+type Interface interface {
+	// EnsureCreated is called when the observed runtime object is created or
+	// updated. After the execution of EnsureCreated, systems being managed have
+	// created or updated system resources. This method must be idempotent.
+	EnsureCreated(ctx context.Context, obj interface{}) error
+	// EnsureDeleted is called when the observed runtime object is requested to be
+	// deleted, which means its DeletionTimestamp is set, but the runtime object
+	// itself is not garbage collected yet. After the execution of EnsureDeleted,
+	// systems being managed have deleted system resources. If deletion could not
+	// be done successfully resource implementations must request to keep
+	// finalizers using the available controller context control flow primitives.
+	// In case EnsureDeleted returns an error, finalizers are kept automatically.
+	// This method must be idempotent.
+	EnsureDeleted(ctx context.Context, obj interface{}) error
+	// Name returns the resource's name used for identification e.g. in logging
+	// and metrics components.
+	Name() string
+}

--- a/resource/spec.go
+++ b/resource/spec.go
@@ -7,7 +7,7 @@ import "context"
 // In that case they are guaranteed to be executed in order one after another.
 type Interface interface {
 	// EnsureCreated is called when the observed runtime object is created or
-	// updated. After the execution of EnsureCreated, systems being managed have
+	// updated. After the successful execution of EnsureCreated, systems being managed have
 	// created or updated system resources. This method must be idempotent.
 	EnsureCreated(ctx context.Context, obj interface{}) error
 	// EnsureDeleted is called when the observed runtime object is requested to be


### PR DESCRIPTION
We would like to drive a better project and code structure forward. Since we have the `resource` package we should move more resource related code in there and free the `controller` package from it. There are more refactorings and improvements we can do but for now this should be one first step. The change does not break APIs. Code should start to transition towards using the new code locations though. 