### PR TITLE
use new resource interface in controller package

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -23,6 +23,7 @@ import (
 	"github.com/giantswarm/operatorkit/controller/context/reconciliationcanceledcontext"
 	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
 	"github.com/giantswarm/operatorkit/informer"
+	"github.com/giantswarm/operatorkit/resource"
 )
 
 const (
@@ -495,7 +496,7 @@ func (c *Controller) resourceSet(obj interface{}) (*ResourceSet, error) {
 //         DeleteFunc:    deleteFunc,
 //     }
 //
-func ProcessDelete(ctx context.Context, obj interface{}, resources []Resource) error {
+func ProcessDelete(ctx context.Context, obj interface{}, resources []resource.Interface) error {
 	if len(resources) == 0 {
 		return microerror.Maskf(executionFailedError, "resources must not be empty")
 	}
@@ -536,7 +537,7 @@ func ProcessDelete(ctx context.Context, obj interface{}, resources []Resource) e
 //         UpdateFunc:    updateFunc,
 //     }
 //
-func ProcessUpdate(ctx context.Context, obj interface{}, resources []Resource) error {
+func ProcessUpdate(ctx context.Context, obj interface{}, resources []resource.Interface) error {
 	if len(resources) == 0 {
 		return microerror.Maskf(executionFailedError, "resources must not be empty")
 	}

--- a/controller/controller_cancel_crud_test.go
+++ b/controller/controller_cancel_crud_test.go
@@ -11,11 +11,12 @@ import (
 
 	"github.com/giantswarm/operatorkit/controller/context/reconciliationcanceledcontext"
 	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
+	"github.com/giantswarm/operatorkit/resource"
 )
 
 func Test_ProcessDelete_CRUD(t *testing.T) {
 	testCases := []struct {
-		Resources     []Resource
+		Resources     []resource.Interface
 		ExpectedOrder []string
 		ErrorMatcher  func(err error) bool
 	}{
@@ -29,7 +30,7 @@ func Test_ProcessDelete_CRUD(t *testing.T) {
 
 		// Test 1 ensures ProcessDelete calls EnsureDeleted method of the resource.
 		{
-			Resources: []Resource{
+			Resources: []resource.Interface{
 				newTestCRUDResource("r0"),
 			},
 			ExpectedOrder: []string{
@@ -46,7 +47,7 @@ func Test_ProcessDelete_CRUD(t *testing.T) {
 		// Test 2 ensures ProcessDelete executes all the resources in
 		// the expected order.
 		{
-			Resources: []Resource{
+			Resources: []resource.Interface{
 				newTestCRUDResource("r0"),
 				newTestCRUDResource("r1"),
 			},
@@ -71,7 +72,7 @@ func Test_ProcessDelete_CRUD(t *testing.T) {
 		// Test 3 ensures ProcessDelete executes resources in the
 		// expected order until the reconciliation gets canceled.
 		{
-			Resources: []Resource{
+			Resources: []resource.Interface{
 				newTestCRUDResource("r0"),
 				newTestCRUDResource("r1"),
 				newTestCRUDResource("r2").CancelReconciliationAt("GetDesiredState"),
@@ -101,7 +102,7 @@ func Test_ProcessDelete_CRUD(t *testing.T) {
 		// Test 4 ensures ProcessDelete executes next resource after
 		// resourcecanceledcontext is cancelled.
 		{
-			Resources: []Resource{
+			Resources: []resource.Interface{
 				newTestCRUDResource("r0").CancelResourceAt("ApplyDeleteChange"),
 				newTestCRUDResource("r1"),
 				newTestCRUDResource("r2").CancelResourceAt("GetDesiredState"),
@@ -166,7 +167,7 @@ func Test_ProcessDelete_CRUD(t *testing.T) {
 
 func Test_ProcessUpdate_CRUD(t *testing.T) {
 	testCases := []struct {
-		Resources     []Resource
+		Resources     []resource.Interface
 		ExpectedOrder []string
 		ErrorMatcher  func(err error) bool
 	}{
@@ -180,7 +181,7 @@ func Test_ProcessUpdate_CRUD(t *testing.T) {
 
 		// Test 1 ensures ProcessUpdate calls EnsureDeleted method of the resource.
 		{
-			Resources: []Resource{
+			Resources: []resource.Interface{
 				newTestCRUDResource("r0"),
 			},
 			ExpectedOrder: []string{
@@ -197,7 +198,7 @@ func Test_ProcessUpdate_CRUD(t *testing.T) {
 		// Test 2 ensures ProcessUpdate executes all the resources in
 		// the expected order.
 		{
-			Resources: []Resource{
+			Resources: []resource.Interface{
 				newTestCRUDResource("r0"),
 				newTestCRUDResource("r1"),
 			},
@@ -222,7 +223,7 @@ func Test_ProcessUpdate_CRUD(t *testing.T) {
 		// Test 3 ensures ProcessUpdate executes resources in the
 		// expected order until the reconciliation gets canceled.
 		{
-			Resources: []Resource{
+			Resources: []resource.Interface{
 				newTestCRUDResource("r0"),
 				newTestCRUDResource("r1"),
 				newTestCRUDResource("r2").CancelReconciliationAt("GetDesiredState"),
@@ -252,7 +253,7 @@ func Test_ProcessUpdate_CRUD(t *testing.T) {
 		// Test 4 ensures ProcessUpdate executes next resource after
 		// resourcecanceledcontext is cancelled.
 		{
-			Resources: []Resource{
+			Resources: []resource.Interface{
 				newTestCRUDResource("r0").CancelResourceAt("ApplyDeleteChange"),
 				newTestCRUDResource("r1"),
 				newTestCRUDResource("r2").CancelResourceAt("GetDesiredState"),

--- a/controller/controller_cancel_test.go
+++ b/controller/controller_cancel_test.go
@@ -7,11 +7,12 @@ import (
 
 	"github.com/giantswarm/operatorkit/controller/context/reconciliationcanceledcontext"
 	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
+	"github.com/giantswarm/operatorkit/resource"
 )
 
 func Test_ProcessDelete(t *testing.T) {
 	testCases := []struct {
-		Resources     []Resource
+		Resources     []resource.Interface
 		ExpectedOrder []string
 		ErrorMatcher  func(err error) bool
 	}{
@@ -25,7 +26,7 @@ func Test_ProcessDelete(t *testing.T) {
 
 		// Test 1 ensures ProcessDelete calls EnsureDeleted method of the resource.
 		{
-			Resources: []Resource{
+			Resources: []resource.Interface{
 				newTestResource("r0"),
 			},
 			ExpectedOrder: []string{
@@ -37,7 +38,7 @@ func Test_ProcessDelete(t *testing.T) {
 		// Test 2 ensures ProcessDelete executes all the resources in
 		// the expected order.
 		{
-			Resources: []Resource{
+			Resources: []resource.Interface{
 				newTestResource("r0"),
 				newTestResource("r1"),
 			},
@@ -51,7 +52,7 @@ func Test_ProcessDelete(t *testing.T) {
 		// Test 3 ensures ProcessDelete executes resources in the
 		// expected order until the reconciliation gets canceled.
 		{
-			Resources: []Resource{
+			Resources: []resource.Interface{
 				newTestResource("r0"),
 				newTestResource("r1"),
 				newTestResource("r2").SetReconcilationCancelledAt("EnsureDeleted"),
@@ -68,7 +69,7 @@ func Test_ProcessDelete(t *testing.T) {
 		// Test 4 ensures ProcessDelete executes next resource after
 		// resourcecanceledcontext is cancelled.
 		{
-			Resources: []Resource{
+			Resources: []resource.Interface{
 				newTestResource("r0"),
 				newTestResource("r1"),
 				newTestResource("r2").CancelResourceAt("EnsureDeleted"),
@@ -109,7 +110,7 @@ func Test_ProcessDelete(t *testing.T) {
 
 func Test_ProcessUpdate(t *testing.T) {
 	testCases := []struct {
-		Resources     []Resource
+		Resources     []resource.Interface
 		ExpectedOrder []string
 		ErrorMatcher  func(err error) bool
 	}{
@@ -123,7 +124,7 @@ func Test_ProcessUpdate(t *testing.T) {
 
 		// Test 1 ensures ProcessUpdate calls EnsureCreated method of the resource.
 		{
-			Resources: []Resource{
+			Resources: []resource.Interface{
 				newTestResource("r0"),
 			},
 			ExpectedOrder: []string{
@@ -135,7 +136,7 @@ func Test_ProcessUpdate(t *testing.T) {
 		// Test 2 ensures ProcessUpdate executes all resources in the
 		// expected order.
 		{
-			Resources: []Resource{
+			Resources: []resource.Interface{
 				newTestResource("r0"),
 				newTestResource("r1"),
 			},
@@ -149,7 +150,7 @@ func Test_ProcessUpdate(t *testing.T) {
 		// Test 3 ensures ProcessUpdate executes resources in the
 		// expected order until the reconciliation gets canceled.
 		{
-			Resources: []Resource{
+			Resources: []resource.Interface{
 				newTestResource("r0"),
 				newTestResource("r1"),
 				newTestResource("r2").SetReconcilationCancelledAt("EnsureCreated"),
@@ -166,7 +167,7 @@ func Test_ProcessUpdate(t *testing.T) {
 		// Test 4 ensures ProcessUpdate executes next resource after
 		// resourcecanceledcontext is cancelled.
 		{
-			Resources: []Resource{
+			Resources: []resource.Interface{
 				newTestResource("r0"),
 				newTestResource("r1"),
 				newTestResource("r2").CancelResourceAt("EnsureCreated"),

--- a/controller/integration/test/controlflow/controlflow_test.go
+++ b/controller/integration/test/controlflow/controlflow_test.go
@@ -14,10 +14,10 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/operatorkit/controller"
 	"github.com/giantswarm/operatorkit/controller/integration/testresource"
 	"github.com/giantswarm/operatorkit/controller/integration/wrapper"
 	"github.com/giantswarm/operatorkit/controller/integration/wrapper/drainerconfig"
+	"github.com/giantswarm/operatorkit/resource"
 )
 
 const (
@@ -244,13 +244,11 @@ func Test_Finalizer_Integration_Controlflow(t *testing.T) {
 	}
 }
 
-func newHarness(namespace string, controllerName string, resource *testresource.Resource) (*drainerconfig.Wrapper, error) {
-	resources := []controller.Resource{
-		controller.Resource(resource),
-	}
-
+func newHarness(namespace string, controllerName string, r *testresource.Resource) (*drainerconfig.Wrapper, error) {
 	c := drainerconfig.Config{
-		Resources: resources,
+		Resources: []resource.Interface{
+			r,
+		},
 
 		Name:      controllerName,
 		Namespace: namespace,

--- a/controller/integration/test/error/error_test.go
+++ b/controller/integration/test/error/error_test.go
@@ -13,9 +13,9 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/operatorkit/controller"
 	"github.com/giantswarm/operatorkit/controller/integration/testresource"
 	"github.com/giantswarm/operatorkit/controller/integration/wrapper/drainerconfig"
+	"github.com/giantswarm/operatorkit/resource"
 )
 
 const (
@@ -65,7 +65,7 @@ func Test_Controller_Integration_Error(t *testing.T) {
 		}
 	}
 
-	resources := []controller.Resource{
+	resources := []resource.Interface{
 		rA,
 		rB,
 	}

--- a/controller/integration/test/parallel/parallel_test.go
+++ b/controller/integration/test/parallel/parallel_test.go
@@ -16,9 +16,9 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/operatorkit/controller"
 	"github.com/giantswarm/operatorkit/controller/integration/testresource"
 	"github.com/giantswarm/operatorkit/controller/integration/wrapper/drainerconfig"
+	"github.com/giantswarm/operatorkit/resource"
 )
 
 const (
@@ -381,13 +381,11 @@ func Test_Finalizer_Integration_Parallel(t *testing.T) {
 	}
 }
 
-func newHarness(namespace string, controllerName string, resource *testresource.Resource) (*drainerconfig.Wrapper, error) {
-	resources := []controller.Resource{
-		controller.Resource(resource),
-	}
-
+func newHarness(namespace string, controllerName string, r *testresource.Resource) (*drainerconfig.Wrapper, error) {
 	c := drainerconfig.Config{
-		Resources: resources,
+		Resources: []resource.Interface{
+			r,
+		},
 
 		Name:      controllerName,
 		Namespace: namespace,

--- a/controller/integration/test/reconciliation/reconciliation_test.go
+++ b/controller/integration/test/reconciliation/reconciliation_test.go
@@ -11,9 +11,9 @@ import (
 	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
 	"github.com/giantswarm/backoff"
 	"github.com/giantswarm/microerror"
-	"github.com/giantswarm/operatorkit/controller"
 	"github.com/giantswarm/operatorkit/controller/integration/testresource"
 	"github.com/giantswarm/operatorkit/controller/integration/wrapper/drainerconfig"
+	"github.com/giantswarm/operatorkit/resource"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -33,22 +33,20 @@ func Test_Finalizer_Integration_Reconciliation(t *testing.T) {
 
 	ctx := context.Background()
 
-	var tr *testresource.Resource
+	var r *testresource.Resource
 	{
 		c := testresource.Config{}
 
-		tr, err = testresource.New(c)
+		r, err = testresource.New(c)
 		if err != nil {
 			t.Fatal("expected", nil, "got", err)
 		}
 	}
 
-	resources := []controller.Resource{
-		controller.Resource(tr),
-	}
-
 	c := drainerconfig.Config{
-		Resources: resources,
+		Resources: []resource.Interface{
+			r,
+		},
 
 		Name:      operatorName,
 		Namespace: testNamespace,
@@ -140,11 +138,11 @@ func Test_Finalizer_Integration_Reconciliation(t *testing.T) {
 	//
 	{
 		o := func() error {
-			if tr.CreateCount() != 4 {
-				return microerror.Maskf(countMismatchError, "EnsureCreated was hit %v times, want %v", tr.CreateCount(), 4)
+			if r.CreateCount() != 4 {
+				return microerror.Maskf(countMismatchError, "EnsureCreated was hit %v times, want %v", r.CreateCount(), 4)
 			}
-			if tr.DeleteCount() != 0 {
-				return microerror.Maskf(countMismatchError, "EnsureDeleted was hit %v times, want %v", tr.DeleteCount(), 0)
+			if r.DeleteCount() != 0 {
+				return microerror.Maskf(countMismatchError, "EnsureDeleted was hit %v times, want %v", r.DeleteCount(), 0)
 			}
 			return nil
 		}
@@ -194,11 +192,11 @@ func Test_Finalizer_Integration_Reconciliation(t *testing.T) {
 	// 		EnsureCreated: 4, EnsureDeleted: 1
 	{
 		o := func() error {
-			if tr.CreateCount() != 4 {
-				return microerror.Maskf(countMismatchError, "EnsureCreated was hit %v times, want %v", tr.CreateCount(), 4)
+			if r.CreateCount() != 4 {
+				return microerror.Maskf(countMismatchError, "EnsureCreated was hit %v times, want %v", r.CreateCount(), 4)
 			}
-			if tr.DeleteCount() != 1 {
-				return microerror.Maskf(countMismatchError, "EnsureDeleted was hit %v times, want %v", tr.DeleteCount(), 1)
+			if r.DeleteCount() != 1 {
+				return microerror.Maskf(countMismatchError, "EnsureDeleted was hit %v times, want %v", r.DeleteCount(), 1)
 			}
 			return nil
 		}

--- a/controller/integration/test/statusupdate/status_update_test.go
+++ b/controller/integration/test/statusupdate/status_update_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/giantswarm/operatorkit/controller"
 	"github.com/giantswarm/operatorkit/controller/integration/wrapper/drainerconfig"
+	"github.com/giantswarm/operatorkit/resource"
 )
 
 const (
@@ -50,7 +51,7 @@ func Test_Finalizer_Integration_StatusUpdate(t *testing.T) {
 	var drainerConfigWrapper *drainerconfig.Wrapper
 	{
 		c := drainerconfig.Config{
-			Resources: []controller.Resource{
+			Resources: []resource.Interface{
 				r,
 			},
 

--- a/controller/integration/testresourceset/resource_set.go
+++ b/controller/integration/testresourceset/resource_set.go
@@ -6,24 +6,24 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/giantswarm/operatorkit/controller"
-
 	"github.com/giantswarm/operatorkit/controller/integration/testresource"
+	"github.com/giantswarm/operatorkit/resource"
 )
 
 type Config struct {
 	K8sClient kubernetes.Interface
 	Logger    micrologger.Logger
-	Resources []controller.Resource
+	Resources []resource.Interface
 
 	ProjectName string
 }
 
 func New(config Config) (*controller.ResourceSet, error) {
 	var err error
-	var resources []controller.Resource
+	var resources []resource.Interface
 
 	if len(config.Resources) == 0 {
-		var tr controller.Resource
+		var tr resource.Interface
 		{
 			c := testresource.Config{}
 
@@ -33,7 +33,7 @@ func New(config Config) (*controller.ResourceSet, error) {
 			}
 		}
 
-		resources = []controller.Resource{
+		resources = []resource.Interface{
 			tr,
 		}
 	} else {

--- a/controller/integration/wrapper/configmap/wrapper.go
+++ b/controller/integration/wrapper/configmap/wrapper.go
@@ -16,10 +16,11 @@ import (
 	"github.com/giantswarm/operatorkit/controller"
 	"github.com/giantswarm/operatorkit/controller/integration/testresourceset"
 	"github.com/giantswarm/operatorkit/informer"
+	"github.com/giantswarm/operatorkit/resource"
 )
 
 type Config struct {
-	Resources []controller.Resource
+	Resources []resource.Interface
 
 	Name      string
 	Namespace string

--- a/controller/integration/wrapper/drainerconfig/wrapper.go
+++ b/controller/integration/wrapper/drainerconfig/wrapper.go
@@ -19,10 +19,11 @@ import (
 	"github.com/giantswarm/operatorkit/controller"
 	"github.com/giantswarm/operatorkit/controller/integration/testresourceset"
 	"github.com/giantswarm/operatorkit/informer"
+	"github.com/giantswarm/operatorkit/resource"
 )
 
 type Config struct {
-	Resources []controller.Resource
+	Resources []resource.Interface
 
 	Name      string
 	Namespace string

--- a/controller/patch_no_panic_test.go
+++ b/controller/patch_no_panic_test.go
@@ -3,12 +3,14 @@ package controller
 import (
 	"context"
 	"testing"
+
+	"github.com/giantswarm/operatorkit/resource"
 )
 
 func Test_Controller_Resource_PatchNoPanic(t *testing.T) {
 	testCases := []struct {
-		ProcessMethod func(ctx context.Context, obj interface{}, rs []Resource) error
-		Resources     []Resource
+		ProcessMethod func(ctx context.Context, obj interface{}, rs []resource.Interface) error
+		Resources     []resource.Interface
 		ErrorMatcher  func(err error) bool
 	}{
 		// Test 0 ensures ProcessDelete returns an error in case no resources are
@@ -23,7 +25,7 @@ func Test_Controller_Resource_PatchNoPanic(t *testing.T) {
 		// resource.
 		{
 			ProcessMethod: ProcessDelete,
-			Resources: []Resource{
+			Resources: []resource.Interface{
 				&testResourcePatchNoPanic{},
 			},
 			ErrorMatcher: nil,
@@ -32,7 +34,7 @@ func Test_Controller_Resource_PatchNoPanic(t *testing.T) {
 		// Test 2 ensures ProcessDelete does not panic when executing two resources.
 		{
 			ProcessMethod: ProcessDelete,
-			Resources: []Resource{
+			Resources: []resource.Interface{
 				&testResourcePatchNoPanic{},
 				&testResourcePatchNoPanic{},
 			},
@@ -51,7 +53,7 @@ func Test_Controller_Resource_PatchNoPanic(t *testing.T) {
 		// resource.
 		{
 			ProcessMethod: ProcessUpdate,
-			Resources: []Resource{
+			Resources: []resource.Interface{
 				&testResourcePatchNoPanic{},
 			},
 			ErrorMatcher: nil,
@@ -60,7 +62,7 @@ func Test_Controller_Resource_PatchNoPanic(t *testing.T) {
 		// Test 5 ensures ProcessUpdate does not panic when executing two resources.
 		{
 			ProcessMethod: ProcessUpdate,
-			Resources: []Resource{
+			Resources: []resource.Interface{
 				&testResourcePatchNoPanic{},
 				&testResourcePatchNoPanic{},
 			},

--- a/controller/resource_set.go
+++ b/controller/resource_set.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/giantswarm/operatorkit/controller/context/finalizerskeptcontext"
 	"github.com/giantswarm/operatorkit/controller/context/updateallowedcontext"
+	"github.com/giantswarm/operatorkit/resource"
 )
 
 type ResourceSetConfig struct {
@@ -26,14 +27,14 @@ type ResourceSetConfig struct {
 	// Resources is the list of controller resources being executed on runtime
 	// object reconciliation if Handles returns true when asked by the
 	// controller. Resources are executed in given order.
-	Resources []Resource
+	Resources []resource.Interface
 }
 
 type ResourceSet struct {
 	handles   func(obj interface{}) bool
 	initCtx   func(ctx context.Context, obj interface{}) (context.Context, error)
 	logger    micrologger.Logger
-	resources []Resource
+	resources []resource.Interface
 }
 
 func NewResourceSet(c ResourceSetConfig) (*ResourceSet, error) {
@@ -79,6 +80,6 @@ func (r *ResourceSet) Handles(obj interface{}) bool {
 	return r.handles(obj)
 }
 
-func (r *ResourceSet) Resources() []Resource {
+func (r *ResourceSet) Resources() []resource.Interface {
 	return r.resources
 }

--- a/example/memcached-operator/controller/memcached.go
+++ b/example/memcached-operator/controller/memcached.go
@@ -9,9 +9,10 @@ import (
 
 	"github.com/giantswarm/operatorkit/client/k8scrdclient"
 	"github.com/giantswarm/operatorkit/controller"
-	"github.com/giantswarm/operatorkit/example/memcached-operator/controller/resource"
+	controllerresource "github.com/giantswarm/operatorkit/example/memcached-operator/controller/resource"
 	"github.com/giantswarm/operatorkit/example/memcached-operator/logger"
 	"github.com/giantswarm/operatorkit/informer"
+	"github.com/giantswarm/operatorkit/resource"
 )
 
 const name = "memcached-operator"
@@ -38,29 +39,29 @@ func NewMemcached(config Config) (*Memcached, error) {
 		watcher    = config.G8sClient.ExampleV1alpha1().MemcachedConfigs("")
 	)
 
-	var deploymentsResource controller.Resource
+	var deploymentsResource resource.Interface
 	{
-		c := resource.DeploymentsConfig{
+		c := controllerresource.DeploymentsConfig{
 			K8sClient: config.K8sClient,
 		}
 
-		deploymentsResource, err = resource.NewDeployments(c)
+		deploymentsResource, err = controllerresource.NewDeployments(c)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
 	}
 
-	var servicesResource controller.Resource
+	var servicesResource resource.Interface
 	{
-		c := resource.ServicesConfig{}
+		c := controllerresource.ServicesConfig{}
 
-		servicesResource, err = resource.NewServices(c)
+		servicesResource, err = controllerresource.NewServices(c)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
 	}
 
-	resources := []controller.Resource{
+	resources := []resource.Interface{
 		deploymentsResource,
 		servicesResource,
 	}
@@ -83,7 +84,6 @@ func NewMemcached(config Config) (*Memcached, error) {
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
-
 	}
 
 	// resourceSets is used in more complex operators that support multiple

--- a/example/memcached-operator/controller/simple_resource_router.go
+++ b/example/memcached-operator/controller/simple_resource_router.go
@@ -5,11 +5,12 @@ import (
 
 	"github.com/giantswarm/operatorkit/controller"
 	"github.com/giantswarm/operatorkit/example/memcached-operator/logger"
+	"github.com/giantswarm/operatorkit/resource"
 )
 
 // newSimpleResourceSets creates a list if resource sets which handles all
 // reconciled objects. In this case with only a single resource set.
-func newSimpleResourceSets(resources []controller.Resource) ([]*controller.ResourceSet, error) {
+func newSimpleResourceSets(resources []resource.Interface) ([]*controller.ResourceSet, error) {
 	var err error
 
 	var set *controller.ResourceSet


### PR DESCRIPTION
Based on [`move-crud-resource`](https://github.com/giantswarm/operatorkit/pull/310). Here we start to use the new resource interface in the `controller` package. 