### PR TITLE
Update subresource by update function

### DIFF
--- a/client/k8scrdclient/k8scrdclient.go
+++ b/client/k8scrdclient/k8scrdclient.go
@@ -126,7 +126,7 @@ func (c *CRDClient) ensureStatusSubresourceCreated(ctx context.Context, customRe
 
 		if manifest.Spec.Subresources == nil || manifest.Spec.Subresources.Status == nil {
 			customResource.SetResourceVersion(manifest.ResourceVersion)
-			_, err = c.k8sExtClient.ApiextensionsV1beta1().CustomResourceDefinitions().UpdateStatus(customResource)
+			_, err = c.k8sExtClient.ApiextensionsV1beta1().CustomResourceDefinitions().Update(customResource)
 			if err != nil {
 				return microerror.Mask(err)
 			}


### PR DESCRIPTION
Toward https://github.com/giantswarm/giantswarm/issues/7299

SInce `Status` subresource is a part of spec, we should update it through `.Update` function. 

Already tested in `centaur/h0cg9` 