### PR TITLE
Clear resource in context in each loop.

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -503,23 +503,23 @@ func ProcessDelete(ctx context.Context, obj interface{}, resources []resource.In
 
 	ctx = reconciliationcanceledcontext.NewContext(ctx, make(chan struct{}))
 
+	defer func() {
+		ctx = unsetLoggerCtxValue(ctx, loggerKeyResource)
+	}()
 	for _, r := range resources {
 		ctx = setLoggerCtxValue(ctx, loggerKeyResource, r.Name())
 		ctx = resourcecanceledcontext.NewContext(ctx, make(chan struct{}))
 
 		err := r.EnsureDeleted(ctx, obj)
 		if err != nil {
-			ctx = unsetLoggerCtxValue(ctx, loggerKeyResource)
 			return microerror.Mask(err)
 		}
 
 		if reconciliationcanceledcontext.IsCanceled(ctx) {
-			ctx = unsetLoggerCtxValue(ctx, loggerKeyResource)
 			return nil
 		}
 	}
 
-	ctx = unsetLoggerCtxValue(ctx, loggerKeyResource)
 	return nil
 }
 
@@ -547,23 +547,23 @@ func ProcessUpdate(ctx context.Context, obj interface{}, resources []resource.In
 
 	ctx = reconciliationcanceledcontext.NewContext(ctx, make(chan struct{}))
 
+	defer func() {
+		ctx = unsetLoggerCtxValue(ctx, loggerKeyResource)
+	}()
 	for _, r := range resources {
 		ctx = setLoggerCtxValue(ctx, loggerKeyResource, r.Name())
 		ctx = resourcecanceledcontext.NewContext(ctx, make(chan struct{}))
 
 		err := r.EnsureCreated(ctx, obj)
 		if err != nil {
-			ctx = unsetLoggerCtxValue(ctx, loggerKeyResource)
 			return microerror.Mask(err)
 		}
 
 		if reconciliationcanceledcontext.IsCanceled(ctx) {
-			ctx = unsetLoggerCtxValue(ctx, loggerKeyResource)
 			return nil
 		}
 	}
 
-	ctx = unsetLoggerCtxValue(ctx, loggerKeyResource)
 	return nil
 }
 

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -509,14 +509,17 @@ func ProcessDelete(ctx context.Context, obj interface{}, resources []resource.In
 
 		err := r.EnsureDeleted(ctx, obj)
 		if err != nil {
+			ctx = unsetLoggerCtxValue(ctx, loggerKeyResource)
 			return microerror.Mask(err)
 		}
 
 		if reconciliationcanceledcontext.IsCanceled(ctx) {
+			ctx = unsetLoggerCtxValue(ctx, loggerKeyResource)
 			return nil
 		}
 	}
 
+	ctx = unsetLoggerCtxValue(ctx, loggerKeyResource)
 	return nil
 }
 
@@ -550,14 +553,17 @@ func ProcessUpdate(ctx context.Context, obj interface{}, resources []resource.In
 
 		err := r.EnsureCreated(ctx, obj)
 		if err != nil {
+			ctx = unsetLoggerCtxValue(ctx, loggerKeyResource)
 			return microerror.Mask(err)
 		}
 
 		if reconciliationcanceledcontext.IsCanceled(ctx) {
+			ctx = unsetLoggerCtxValue(ctx, loggerKeyResource)
 			return nil
 		}
 	}
 
+	ctx = unsetLoggerCtxValue(ctx, loggerKeyResource)
 	return nil
 }
 
@@ -569,6 +575,19 @@ func setLoggerCtxValue(ctx context.Context, key, value string) context.Context {
 	}
 
 	m.KeyVals[key] = value
+
+	return ctx
+}
+
+func unsetLoggerCtxValue(ctx context.Context, key string) context.Context {
+	m, ok := loggermeta.FromContext(ctx)
+	if !ok {
+		m = loggermeta.New()
+		ctx = loggermeta.NewContext(ctx, m)
+		return ctx
+	}
+
+	delete(m.KeyVals, key)
 
 	return ctx
 }


### PR DESCRIPTION
We are not cleaning the resource key after finishing the looping each resource, so sometimes logs are hard to understand as it indicated some resources. 
For instance, 
```
D 10/22 13:45:23 /apis/application.giantswarm.io/v1alpha1/namespaces/giantswarm/charts/aqua-app-enforcer statusv1 reconciling object | operatorkit/controller/controller.go:295 | controller=chart-operator-chart | event=update | loop=79 | version=13500
```

This is obviously `controller` stack, but it shows the log itself like from `resource` perspective. 

By this change, we would no longer see the dangling `resource` key in the context. 