### PR TITLE
Checking port-forwarding error as reverse order

### DIFF
--- a/controller/error.go
+++ b/controller/error.go
@@ -63,6 +63,10 @@ func IsPortforward(err error) bool {
 		return true
 	}
 
+	if strings.Contains(c.Error(), "error copying from remote stream to local connection") {
+		return true
+	}
+
 	return false
 }
 


### PR DESCRIPTION
Toward https://github.com/giantswarm/giantswarm/issues/7313

In some cases, errors related to port-forward have a different sentence that we are expecting, 
```
E 10/31 07:05:38 /apis/application.giantswarm.io/v1alpha1/namespaces/giantswarm/charts/aqua-app-server statusv1 caught third party runtime error | operatorkit/controller/controller.go:429 | controller=chart-operator-chart | event=update | loop=1057 | stack=&errors.errorString{s:"error copying from remote stream to local connection: readfrom tcp4 127.0.0.1:37325->127.0.0.1:48982: write tcp4 127.0.0.1:37325->127.0.0.1:48982: write: broken pipe"} | version=1023827
```
See `copying from remote stream to local connection`.
Currently, we only compare it with `error copying from local connection to remote stream` so it does not regard it as port-forwarding. 