### PR TITLE
deprecate client package

### DIFF
--- a/client/k8scrdclient/k8scrdclient.go
+++ b/client/k8scrdclient/k8scrdclient.go
@@ -1,3 +1,4 @@
+// Package k8scrdclient is deprecated and moved to github.com/giantswarm/k8sclient.
 package k8scrdclient
 
 import (

--- a/client/k8srestconfig/k8s_rest_config.go
+++ b/client/k8srestconfig/k8s_rest_config.go
@@ -1,5 +1,4 @@
-// Package k8srestconfig provides interface to create client-go rest config
-// which can be used to construct various clients.
+// Package k8srestconfig is deprecated and moved to github.com/giantswarm/k8sclient.
 //
 // Example usage:
 //


### PR DESCRIPTION
We want to use github.com/giantswarm/k8sclient in `operatorkit`. Right now `k8sclient` imports `operatorkit`. The idea is to move the client package to `k8sclient` and sort out the dependency graph. I will follow up with a PR in `k8sclient`. 