### PR TITLE
Add flag for kubeconfig file path

### DIFF
--- a/flag/service/kubernetes/kubernetes.go
+++ b/flag/service/kubernetes/kubernetes.go
@@ -8,9 +8,10 @@ import (
 // Kubernetes is a data structure to hold Kubernetes specific command line
 // configuration flags.
 type Kubernetes struct {
-	Address    string
-	InCluster  string
-	KubeConfig string
-	TLS        tls.TLS
-	Watch      watch.Watch
+	Address        string
+	InCluster      string
+	KubeConfig     string
+	KubeConfigPath string
+	TLS            tls.TLS
+	Watch          watch.Watch
 }


### PR DESCRIPTION
When configuring k8sclient in operators, one may either specify path to kubectl
configuration file or fill parameters for restconfig.