### PR TITLE
Use micrologger v0.1.0

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -76,7 +76,7 @@
   name = "github.com/giantswarm/e2e-harness"
   packages = ["pkg/harness"]
   pruneopts = "UT"
-  revision = "be7852f38d3ea98622ce0542bc39cc522daaf6f9"
+  revision = "056fbe4ee7d617af09a5e0faed14af86b32aafea"
 
 [[projects]]
   branch = "master"
@@ -84,18 +84,18 @@
   name = "github.com/giantswarm/exporterkit"
   packages = ["collector"]
   pruneopts = "UT"
-  revision = "9749deade60f7624620aa7158a4f38c87ea23795"
+  revision = "4a78fcf3b86d91e1354f5ebc9f21fe2b4ac3041e"
 
 [[projects]]
   branch = "master"
-  digest = "1:ca9ad5887021e13fca3a1aa33a58668a0061b3a03bd7dfc2d36c38dedf56f572"
+  digest = "1:a6fdcbdc9a98d2174017f2a00e32e835c3ee6739e15a476285e981ab6d7e4627"
   name = "github.com/giantswarm/k8sclient"
   packages = [
     ".",
     "k8scrdclient",
   ]
   pruneopts = "UT"
-  revision = "6cb127468cd6b30eaf8030b875f796e34b481938"
+  revision = "78de8231ec254eba941e9999c2b13581b2d2103b"
 
 [[projects]]
   branch = "master"
@@ -106,8 +106,7 @@
   revision = "e0ebc4ecf5a515b8f2a33257d08962e387120a77"
 
 [[projects]]
-  branch = "master"
-  digest = "1:c313924ca7110c452a83502384552f4dd2ed25dd0f3ab8aa8a34707315243561"
+  digest = "1:c497795cf3848ef5a655d53f24dfc670c72f9b2fc41eeda495d66542ae6bd017"
   name = "github.com/giantswarm/micrologger"
   packages = [
     ".",
@@ -115,7 +114,8 @@
     "microloggertest",
   ]
   pruneopts = "UT"
-  revision = "d866337f739365a54de5924b8a7b29df17693ef8"
+  revision = "c87486c7d20d7878ad57a09d379d7d59328b472e"
+  version = "v0.1.0"
 
 [[projects]]
   branch = "master"
@@ -818,6 +818,8 @@
     "k8s.io/apimachinery/pkg/api/errors",
     "k8s.io/apimachinery/pkg/api/meta",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
+    "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured",
+    "k8s.io/apimachinery/pkg/labels",
     "k8s.io/apimachinery/pkg/runtime",
     "k8s.io/apimachinery/pkg/runtime/schema",
     "k8s.io/apimachinery/pkg/types",
@@ -825,6 +827,7 @@
     "k8s.io/client-go/kubernetes",
     "k8s.io/client-go/tools/clientcmd",
     "sigs.k8s.io/controller-runtime/pkg/builder",
+    "sigs.k8s.io/controller-runtime/pkg/client/apiutil",
     "sigs.k8s.io/controller-runtime/pkg/controller",
     "sigs.k8s.io/controller-runtime/pkg/event",
     "sigs.k8s.io/controller-runtime/pkg/manager",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -42,7 +42,7 @@
   name = "github.com/giantswarm/microerror"
 
 [[constraint]]
-  branch = "master"
+  version = "v0.1.0"
   name = "github.com/giantswarm/micrologger"
 
 [[constraint]]

--- a/vendor/github.com/giantswarm/k8sclient/Gopkg.lock
+++ b/vendor/github.com/giantswarm/k8sclient/Gopkg.lock
@@ -71,15 +71,15 @@
   revision = "e0ebc4ecf5a515b8f2a33257d08962e387120a77"
 
 [[projects]]
-  branch = "master"
-  digest = "1:90c6d64e0533a0fa637bf64c0fe978e9616971502acea37e76e53ab8c9a6545f"
+  digest = "1:2275349e37657984a6cfc425803962b3f46843532b37b7a4552c5356086dffc6"
   name = "github.com/giantswarm/micrologger"
   packages = [
     ".",
     "loggermeta",
   ]
   pruneopts = "UT"
-  revision = "d866337f739365a54de5924b8a7b29df17693ef8"
+  revision = "c87486c7d20d7878ad57a09d379d7d59328b472e"
+  version = "v0.1.0"
 
 [[projects]]
   digest = "1:0cfcded8689c2c964c223650009c5dd9e283c22d57f18f2335aafa16cc22acf1"

--- a/vendor/github.com/giantswarm/k8sclient/Gopkg.toml
+++ b/vendor/github.com/giantswarm/k8sclient/Gopkg.toml
@@ -40,7 +40,7 @@
 
 [[constraint]]
   name = "github.com/giantswarm/micrologger"
-  branch = "master"
+  version = "v0.1.0"
 
 [[constraint]]
   name = "k8s.io/api"

--- a/vendor/github.com/giantswarm/micrologger/CHANGELOG.md
+++ b/vendor/github.com/giantswarm/micrologger/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] 2020-02-13
+
+### Added
+
+- First release.
+
+[Unreleased]: https://github.com/giantswarm/micrologger/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/giantswarm/micrologger/releases/tag/v0.1.0


### PR DESCRIPTION
We need to pin the micrologger dependency to the v0.1.0 version which is the one using dep instead of newer versions that use go modules.

