### PR TITLE
fix metrics registration via unique constant labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+### Fixed
+
+- Fix collector registration by using constant labels for controller name.
+
+
+
 ## [1.0.0] 2020-05-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix collector registration by using constant labels for controller name.
+- Fix the issue where `operatorkit_controller_creation_timestamp` and `operatorkit_controller_deletion_timestamp` metrics were not emitted for all the controllers.
 
 
 

--- a/controller/collector/set.go
+++ b/controller/collector/set.go
@@ -12,6 +12,8 @@ type SetConfig struct {
 	Logger               micrologger.Logger
 	K8sClient            k8sclient.Interface
 	NewRuntimeObjectFunc func() runtime.Object
+
+	Controller string
 }
 
 // Set is basically only a wrapper for the collector implementations.

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -145,6 +145,8 @@ func New(config Config) (*Controller, error) {
 			Logger:               config.Logger,
 			K8sClient:            config.K8sClient,
 			NewRuntimeObjectFunc: config.NewRuntimeObjectFunc,
+
+			Controller: config.Name,
 		}
 
 		collectorSet, err = collector.NewSet(c)

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -19,6 +19,16 @@ func Test_Controller_Collector_Register(t *testing.T) {
 	prometheus.MustRegister(mustNewTestController("c-2").collector)
 }
 
+func Test_Controller_Collector_Register_Error(t *testing.T) {
+	prometheus.MustRegister(mustNewTestController("same").collector)
+
+	err := prometheus.Register(mustNewTestController("same").collector)
+	_, ok := err.(prometheus.AlreadyRegisteredError)
+	if !ok {
+		panic("registering the same controller collector twice must not be possible")
+	}
+}
+
 func Test_setLoggerCtxValue_doesnt_leak(t *testing.T) {
 	ctx := context.Background()
 

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -4,7 +4,20 @@ import (
 	"context"
 	"reflect"
 	"testing"
+
+	"github.com/giantswarm/k8sclient/v3/pkg/k8sclienttest"
+	"github.com/giantswarm/micrologger/microloggertest"
+	"github.com/prometheus/client_golang/prometheus"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/giantswarm/operatorkit/resource"
 )
+
+func Test_Controller_Collector_Register(t *testing.T) {
+	prometheus.MustRegister(mustNewTestController("c-1").collector)
+	prometheus.MustRegister(mustNewTestController("c-2").collector)
+}
 
 func Test_setLoggerCtxValue_doesnt_leak(t *testing.T) {
 	ctx := context.Background()
@@ -63,4 +76,31 @@ func isValueCtx(ctx interface{}) bool {
 	}
 
 	return true
+}
+
+func mustNewTestController(n string) *Controller {
+	var err error
+
+	var controller *Controller
+	{
+		c := Config{
+			K8sClient: k8sclienttest.NewEmpty(),
+			Logger:    microloggertest.New(),
+			NewRuntimeObjectFunc: func() runtime.Object {
+				return new(corev1.Service)
+			},
+			Resources: []resource.Interface{
+				&testResource{},
+			},
+
+			Name: n,
+		}
+
+		controller, err = New(c)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	return controller
 }


### PR DESCRIPTION
## Checklist

- [x] Update changelog in CHANGELOG.md.



## Context 

Checking in on https://github.com/giantswarm/giantswarm/issues/10553 we noticed we actually have a problem with collector registrations when running multiple controllers in one operator. The best way to sort this out for us was now to define constant labels for the controller running the collector. There is also a minimal unit test proving that it works. Using the same name makes the test panic. 

```
--- FAIL: Test_Controller_Collector_Register (0.00s)
panic: duplicate metrics collector registration attempted [recovered]
	panic: duplicate metrics collector registration attempted

goroutine 47 [running]:
testing.tRunner.func1.1(0x208cee0, 0xc00052c1a0)
	/Users/xh3b4sd/.gvm/gos/go1.14.1/src/testing/testing.go:941 +0x3d0
testing.tRunner.func1(0xc00051f7a0)
	/Users/xh3b4sd/.gvm/gos/go1.14.1/src/testing/testing.go:944 +0x3f9
panic(0x208cee0, 0xc00052c1a0)
	/Users/xh3b4sd/.gvm/gos/go1.14.1/src/runtime/panic.go:967 +0x166
github.com/prometheus/client_golang/prometheus.(*Registry).MustRegister(0xc0001090e0, 0xc000522cf0, 0x1, 0x1)
	/Users/xh3b4sd/go/pkg/mod/github.com/prometheus/client_golang@v1.3.0/prometheus/registry.go:400 +0xad
github.com/prometheus/client_golang/prometheus.MustRegister(...)
	/Users/xh3b4sd/go/pkg/mod/github.com/prometheus/client_golang@v1.3.0/prometheus/registry.go:177
github.com/giantswarm/operatorkit/controller.Test_Controller_Collector_Register(0xc00051f7a0)
	/Users/xh3b4sd/go/src/github.com/giantswarm/operatorkit/controller/controller_test.go:18 +0x133
testing.tRunner(0xc00051f7a0, 0x22bc0f0)
	/Users/xh3b4sd/.gvm/gos/go1.14.1/src/testing/testing.go:992 +0xdc
created by testing.(*T).Run
	/Users/xh3b4sd/.gvm/gos/go1.14.1/src/testing/testing.go:1043 +0x357
FAIL	github.com/giantswarm/operatorkit/controller	0.476s
```