### PR TITLE
Add namespace in config & and wired it to manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Updated
+
+- Add `namespace` into controller setting. 
+
 ## [4.0.0] - 2020-10-27
 
 ## Updated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## Updated
+## Added
 
 - Add `namespace` into controller setting. 
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -101,6 +101,7 @@ type Config struct {
 	// two operators which handle the same resource add two distinct finalizers.
 	Name string
 	// Namespace is where the controller would reconcile the runtime objects.
+	// Empty string means all namespaces.	
 	Namespace string
 	// ResyncPeriod is the duration after which a complete sync with all known
 	// runtime objects the controller watches is performed. Defaults to

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -100,6 +100,8 @@ type Config struct {
 	// The name used should be unique in the kubernetes cluster, to ensure that
 	// two operators which handle the same resource add two distinct finalizers.
 	Name string
+	// Namespace is where the controller would reconcile the runtime objects.
+	Namespace string
 	// ResyncPeriod is the duration after which a complete sync with all known
 	// runtime objects the controller watches is performed. Defaults to
 	// DefaultResyncPeriod.
@@ -128,6 +130,7 @@ type Controller struct {
 	sentry                 sentry.Interface
 
 	name         string
+	namespace    string
 	resyncPeriod time.Duration
 }
 
@@ -230,6 +233,7 @@ func New(config Config) (*Controller, error) {
 		sentry:                 sentryClient,
 
 		name:         config.Name,
+		namespace:    config.Namespace,
 		resyncPeriod: config.ResyncPeriod,
 	}
 
@@ -353,6 +357,7 @@ func (c *Controller) bootWithError(ctx context.Context) error {
 			// MetricsBindAddress is set to 0 in order to disable it. We do this
 			// ourselves.
 			MetricsBindAddress: DisableMetricsServing,
+			Namespace:          c.namespace,
 			SyncPeriod:         to.DurationP(c.resyncPeriod),
 		}
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -101,7 +101,7 @@ type Config struct {
 	// two operators which handle the same resource add two distinct finalizers.
 	Name string
 	// Namespace is where the controller would reconcile the runtime objects.
-	// Empty string means all namespaces.	
+	// Empty string means all namespaces.
 	Namespace string
 	// ResyncPeriod is the duration after which a complete sync with all known
 	// runtime objects the controller watches is performed. Defaults to


### PR DESCRIPTION
At some points, we need to bind the controller to a specific namespace. This change is to set the namespace from the controller generator. 


Slack conversation: https://gigantic.slack.com/archives/C2MS2VB37/p1606222861091500

## Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Update roadmap in ROADMAP.md.
