### PR TITLE
Use micrologger@v0.4.0 Debugf/Errorf

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/giantswarm/exporterkit v0.2.0
 	github.com/giantswarm/k8sclient/v5 v5.0.0
 	github.com/giantswarm/microerror v0.2.1
-	github.com/giantswarm/micrologger v0.3.4
+	github.com/giantswarm/micrologger v0.4.0
 	github.com/giantswarm/to v0.3.0
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/prometheus/client_golang v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -166,6 +166,8 @@ github.com/giantswarm/micrologger v0.3.1/go.mod h1:PjAgtcJ922ZMX/Aa05IPi0bdYvOj2
 github.com/giantswarm/micrologger v0.3.3/go.mod h1:fkzQdDBC6HjJq4nllBDt6XB4t4yeVyhdHKblFX6QoMQ=
 github.com/giantswarm/micrologger v0.3.4 h1:NKD6pz1++Hkq/ulOT9iu7hwTnG3ZfjnPUtuK/tbeCc8=
 github.com/giantswarm/micrologger v0.3.4/go.mod h1:fkzQdDBC6HjJq4nllBDt6XB4t4yeVyhdHKblFX6QoMQ=
+github.com/giantswarm/micrologger v0.4.0 h1:2EpnX86HKpqUNY8C4qbB2SzniB4bgES8Cd/mYrVyOrI=
+github.com/giantswarm/micrologger v0.4.0/go.mod h1:xsD5laBXORMy/P34IHZMK0y/D1gTkYtASUL4gUm5KN4=
 github.com/giantswarm/to v0.3.0 h1:cEzMYkWLGI3cI8x3a0L3nPCQYJTb/cAaqcIPvxnDmpQ=
 github.com/giantswarm/to v0.3.0/go.mod h1:RTRtw+Dyk6YqoiNBOGLO981BqhibtVwogdaFIMO1y/A=
 github.com/giantswarm/versionbundle v0.2.0/go.mod h1:n7GOlSXpX9TpP3EsYhErCjskN++c7uYHEEfV81NCH7s=
@@ -291,6 +293,8 @@ github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.3 h1:x95R7cp+rSeeqAMI2knLtQ0DKlaBhv2NrtrOvafPHRo=
 github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.4 h1:L8R9j+yAqZuZjsqh/z+F1NCffTKKLShY6zXTItVIZ8M=
+github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=

--- a/go.sum
+++ b/go.sum
@@ -164,8 +164,6 @@ github.com/giantswarm/microerror v0.2.1/go.mod h1:1YtJq/m7Vlq1Y6NP7B+SODOKCGlG7e
 github.com/giantswarm/microkit v0.2.0/go.mod h1:1vDHFUN+ZsUahZJ2hgZxcU7nG35Rj484t8Y5akhdRIM=
 github.com/giantswarm/micrologger v0.3.1/go.mod h1:PjAgtcJ922ZMX/Aa05IPi0bdYvOj2P7pZ7+6dBShMQs=
 github.com/giantswarm/micrologger v0.3.3/go.mod h1:fkzQdDBC6HjJq4nllBDt6XB4t4yeVyhdHKblFX6QoMQ=
-github.com/giantswarm/micrologger v0.3.4 h1:NKD6pz1++Hkq/ulOT9iu7hwTnG3ZfjnPUtuK/tbeCc8=
-github.com/giantswarm/micrologger v0.3.4/go.mod h1:fkzQdDBC6HjJq4nllBDt6XB4t4yeVyhdHKblFX6QoMQ=
 github.com/giantswarm/micrologger v0.4.0 h1:2EpnX86HKpqUNY8C4qbB2SzniB4bgES8Cd/mYrVyOrI=
 github.com/giantswarm/micrologger v0.4.0/go.mod h1:xsD5laBXORMy/P34IHZMK0y/D1gTkYtASUL4gUm5KN4=
 github.com/giantswarm/to v0.3.0 h1:cEzMYkWLGI3cI8x3a0L3nPCQYJTb/cAaqcIPvxnDmpQ=

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -259,7 +259,7 @@ func (c *Controller) Boot(ctx context.Context) {
 		err := backoff.RetryNotify(operation, c.backOffFactory(), notifier)
 		if err != nil {
 			c.sentry.Capture(ctx, err)
-			c.logger.LogCtx(ctx, "level", "error", "message", "stop controller boot retries due to too many errors", "stack", microerror.JSON(err))
+			c.logger.Errorf(ctx, err, "stop controller boot retries due to too many errors")
 			os.Exit(1)
 		}
 	})
@@ -307,7 +307,7 @@ func (c *Controller) Reconcile(req reconcile.Request) (reconcile.Result, error) 
 		c.event.Emit(ctx, obj, err)
 		errorGauge.Inc()
 		c.sentry.Capture(ctx, err)
-		c.logger.LogCtx(ctx, "level", "error", "message", "failed to reconcile", "stack", microerror.JSON(err))
+		c.logger.Errorf(ctx, err, "failed to reconcile")
 		return reconcile.Result{}, nil
 	}
 
@@ -347,7 +347,7 @@ func (c *Controller) bootWithError(ctx context.Context) error {
 				}
 
 				errorGauge.Inc()
-				c.logger.LogCtx(ctx, "level", "error", "message", "caught third party runtime error", "stack", microerror.JSON(err))
+				c.logger.Errorf(ctx, err, "caught third party runtime error")
 			},
 		}
 	}
@@ -475,8 +475,8 @@ func (c *Controller) reconcile(ctx context.Context, req reconcile.Request, obj i
 
 	{
 		if c.hasPauseAnnotation(m.GetAnnotations()) {
-			c.logger.LogCtx(ctx, "level", "debug", "message", "found pause annotation")
-			c.logger.LogCtx(ctx, "level", "debug", "message", "cancelling reconciliation")
+			c.logger.Debugf(ctx, "found pause annotation")
+			c.logger.Debugf(ctx, "cancelling reconciliation")
 			return reconcile.Result{}, nil
 		}
 	}

--- a/pkg/controller/finalizer.go
+++ b/pkg/controller/finalizer.go
@@ -119,8 +119,8 @@ func (c *Controller) removeFinalizer(ctx context.Context, obj interface{}) error
 	// replayed. In case we see such a request via the dispatched context, we skip
 	// the finalizer removal.
 	if finalizerskeptcontext.IsKept(ctx) {
-		c.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("did not remove finalizer %#q", finalizerName))
-		c.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finalizer %#q requested to be kept", finalizerName))
+		c.logger.Debugf(ctx, "did not remove finalizer %#q", finalizerName)
+		c.logger.Debugf(ctx, "finalizer %#q requested to be kept", finalizerName)
 
 		return nil
 	}
@@ -136,14 +136,14 @@ func (c *Controller) removeFinalizer(ctx context.Context, obj interface{}) error
 	//     - The object has another finalizer set and we removed ours already.
 	//
 	if !containsString(accessor.GetFinalizers(), finalizerName) {
-		c.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("did not remove finalizer %#q", finalizerName))
-		c.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finalizer %#q not found", finalizerName))
+		c.logger.Debugf(ctx, "did not remove finalizer %#q", finalizerName)
+		c.logger.Debugf(ctx, "finalizer %#q not found", finalizerName)
 
 		return nil
 	}
 
 	{
-		c.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("removing finalizer %#q", finalizerName))
+		c.logger.Debugf(ctx, "removing finalizer %#q", finalizerName)
 
 		o := func() error {
 			newObj := c.newRuntimeObjectFunc()
@@ -190,7 +190,7 @@ func (c *Controller) removeFinalizer(ctx context.Context, obj interface{}) error
 			return microerror.Mask(err)
 		}
 
-		c.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("removed finalizer %#q", finalizerName))
+		c.logger.Debugf(ctx, "removed finalizer %#q", finalizerName)
 		c.removedFinalizersCache.Set(selfLink)
 	}
 

--- a/pkg/resource/k8s/configmapresource/create.go
+++ b/pkg/resource/k8s/configmapresource/create.go
@@ -2,7 +2,6 @@ package configmapresource
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/giantswarm/microerror"
 	corev1 "k8s.io/api/core/v1"
@@ -18,15 +17,15 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 	}
 
 	for _, configMap := range configMaps {
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("creating ConfigMap %#q in namespace %#q", configMap.Name, configMap.Namespace))
+		r.logger.Debugf(ctx, "creating ConfigMap %#q in namespace %#q", configMap.Name, configMap.Namespace)
 
 		_, err = r.k8sClient.CoreV1().ConfigMaps(configMap.Namespace).Create(ctx, configMap, metav1.CreateOptions{})
 		if apierrors.IsAlreadyExists(err) {
-			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("already created ConfigMap %#q in namespace %#q", configMap.Name, configMap.Namespace))
+			r.logger.Debugf(ctx, "already created ConfigMap %#q in namespace %#q", configMap.Name, configMap.Namespace)
 		} else if err != nil {
 			return microerror.Mask(err)
 		} else {
-			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("created ConfigMap %#q in namespace %#q", configMap.Name, configMap.Namespace))
+			r.logger.Debugf(ctx, "created ConfigMap %#q in namespace %#q", configMap.Name, configMap.Namespace)
 		}
 	}
 
@@ -45,7 +44,7 @@ func (r *Resource) newCreateChange(ctx context.Context, obj, currentState, desir
 
 	var configMapsToCreate []*corev1.ConfigMap
 	{
-		r.logger.LogCtx(ctx, "level", "debug", "message", "computing ConfigMaps to create")
+		r.logger.Debugf(ctx, "computing ConfigMaps to create")
 
 		for _, d := range desiredConfigMaps {
 			if !containsConfigMap(currentConfigMaps, d) {
@@ -53,7 +52,7 @@ func (r *Resource) newCreateChange(ctx context.Context, obj, currentState, desir
 			}
 		}
 
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("computed %d ConfigMaps to create", len(configMapsToCreate)))
+		r.logger.Debugf(ctx, "computed %d ConfigMaps to create", len(configMapsToCreate))
 	}
 
 	return configMapsToCreate, nil

--- a/pkg/resource/k8s/configmapresource/delete.go
+++ b/pkg/resource/k8s/configmapresource/delete.go
@@ -2,7 +2,6 @@ package configmapresource
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/giantswarm/microerror"
 	corev1 "k8s.io/api/core/v1"
@@ -17,15 +16,15 @@ func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange inte
 	}
 
 	for _, configMap := range configMapsToDelete {
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting ConfigMap %#q in namespace %#q", configMap.Name, configMap.Namespace))
+		r.logger.Debugf(ctx, "deleting ConfigMap %#q in namespace %#q", configMap.Name, configMap.Namespace)
 
 		err := r.k8sClient.CoreV1().ConfigMaps(configMap.Namespace).Delete(ctx, configMap.Name, metav1.DeleteOptions{})
 		if apierrors.IsNotFound(err) {
-			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("already deleted ConfigMap %#q in namespace %#q", configMap.Name, configMap.Namespace))
+			r.logger.Debugf(ctx, "already deleted ConfigMap %#q in namespace %#q", configMap.Name, configMap.Namespace)
 		} else if err != nil {
 			return microerror.Mask(err)
 		} else {
-			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted ConfigMap %#q in namespace %#q", configMap.Name, configMap.Namespace))
+			r.logger.Debugf(ctx, "deleted ConfigMap %#q in namespace %#q", configMap.Name, configMap.Namespace)
 		}
 	}
 
@@ -53,7 +52,7 @@ func (r *Resource) newDeleteChangeForUpdatePatch(ctx context.Context, obj, curre
 
 	var configMapsToDelete []*corev1.ConfigMap
 	{
-		r.logger.LogCtx(ctx, "level", "debug", "message", "computing ConfigMaps to delete")
+		r.logger.Debugf(ctx, "computing ConfigMaps to delete")
 
 		for _, c := range currentConfigMaps {
 			if !containsConfigMap(desiredConfigMaps, c) {
@@ -61,7 +60,7 @@ func (r *Resource) newDeleteChangeForUpdatePatch(ctx context.Context, obj, curre
 			}
 		}
 
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("computed %d ConfigMaps to delete", len(configMapsToDelete)))
+		r.logger.Debugf(ctx, "computed %d ConfigMaps to delete", len(configMapsToDelete))
 	}
 
 	return configMapsToDelete, nil

--- a/pkg/resource/k8s/configmapresource/update.go
+++ b/pkg/resource/k8s/configmapresource/update.go
@@ -2,7 +2,6 @@ package configmapresource
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/giantswarm/microerror"
 	corev1 "k8s.io/api/core/v1"
@@ -16,14 +15,14 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 	}
 
 	for _, configMap := range configMaps {
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("updating ConfigMap %#q in namespace %#q", configMap.Name, configMap.Namespace))
+		r.logger.Debugf(ctx, "updating ConfigMap %#q in namespace %#q", configMap.Name, configMap.Namespace)
 
 		_, err = r.k8sClient.CoreV1().ConfigMaps(configMap.Namespace).Update(ctx, configMap, metav1.UpdateOptions{})
 		if err != nil {
 			return microerror.Mask(err)
 		}
 
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("updated ConfigMap %#q in namespace %#q", configMap.Name, configMap.Namespace))
+		r.logger.Debugf(ctx, "updated ConfigMap %#q in namespace %#q", configMap.Name, configMap.Namespace)
 	}
 
 	return nil
@@ -41,7 +40,7 @@ func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desir
 
 	var configMapsToUpdate []*corev1.ConfigMap
 	{
-		r.logger.LogCtx(ctx, "level", "debug", "message", "computing ConfigMaps to update")
+		r.logger.Debugf(ctx, "computing ConfigMaps to update")
 
 		for _, c := range currentConfigMaps {
 			for _, d := range desiredConfigMaps {
@@ -52,7 +51,7 @@ func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desir
 			}
 		}
 
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("computed %d ConfigMaps to update", len(configMapsToUpdate)))
+		r.logger.Debugf(ctx, "computed %d ConfigMaps to update", len(configMapsToUpdate))
 	}
 
 	return configMapsToUpdate, nil

--- a/pkg/resource/k8s/secretresource/create.go
+++ b/pkg/resource/k8s/secretresource/create.go
@@ -2,7 +2,6 @@ package secretresource
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/giantswarm/microerror"
 	corev1 "k8s.io/api/core/v1"
@@ -18,15 +17,15 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 	}
 
 	for _, secret := range secrets {
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("creating Secret %#q in namespace %#q", secret.Name, secret.Namespace))
+		r.logger.Debugf(ctx, "creating Secret %#q in namespace %#q", secret.Name, secret.Namespace)
 
 		_, err = r.k8sClient.CoreV1().Secrets(secret.Namespace).Create(ctx, secret, metav1.CreateOptions{})
 		if apierrors.IsAlreadyExists(err) {
-			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("already created Secret %#q in namespace %#q", secret.Name, secret.Namespace))
+			r.logger.Debugf(ctx, "already created Secret %#q in namespace %#q", secret.Name, secret.Namespace)
 		} else if err != nil {
 			return microerror.Mask(err)
 		} else {
-			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("created Secret %#q in namespace %#q", secret.Name, secret.Namespace))
+			r.logger.Debugf(ctx, "created Secret %#q in namespace %#q", secret.Name, secret.Namespace)
 		}
 	}
 
@@ -45,7 +44,7 @@ func (r *Resource) newCreateChange(ctx context.Context, obj, currentState, desir
 
 	var secretsToCreate []*corev1.Secret
 	{
-		r.logger.LogCtx(ctx, "level", "debug", "message", "computing Secrets to create ")
+		r.logger.Debugf(ctx, "computing Secrets to create ")
 
 		for _, d := range desiredSecrets {
 			if !containsSecret(d, currentSecrets) {
@@ -53,7 +52,7 @@ func (r *Resource) newCreateChange(ctx context.Context, obj, currentState, desir
 			}
 		}
 
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("computed %d Secrets to create", len(secretsToCreate)))
+		r.logger.Debugf(ctx, "computed %d Secrets to create", len(secretsToCreate))
 	}
 
 	return secretsToCreate, nil

--- a/pkg/resource/k8s/secretresource/delete.go
+++ b/pkg/resource/k8s/secretresource/delete.go
@@ -2,7 +2,6 @@ package secretresource
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/giantswarm/microerror"
 	corev1 "k8s.io/api/core/v1"
@@ -17,15 +16,15 @@ func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange inte
 	}
 
 	for _, secret := range secretsToDelete {
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting Secret %#q in namespace %#q", secret.Name, secret.Namespace))
+		r.logger.Debugf(ctx, "deleting Secret %#q in namespace %#q", secret.Name, secret.Namespace)
 
 		err := r.k8sClient.CoreV1().Secrets(secret.Namespace).Delete(ctx, secret.Name, metav1.DeleteOptions{})
 		if apierrors.IsNotFound(err) {
-			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("already deleted Secret %#q in namespace %#q", secret.Name, secret.Namespace))
+			r.logger.Debugf(ctx, "already deleted Secret %#q in namespace %#q", secret.Name, secret.Namespace)
 		} else if err != nil {
 			return microerror.Mask(err)
 		} else {
-			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted Secret %#q in namespace %#q", secret.Name, secret.Namespace))
+			r.logger.Debugf(ctx, "deleted Secret %#q in namespace %#q", secret.Name, secret.Namespace)
 		}
 	}
 
@@ -53,7 +52,7 @@ func (r *Resource) newDeleteChangeForUpdatePatch(ctx context.Context, obj, curre
 
 	var secretsToDelete []*corev1.Secret
 	{
-		r.logger.LogCtx(ctx, "level", "debug", "message", "computing Secrets to delete")
+		r.logger.Debugf(ctx, "computing Secrets to delete")
 
 		for _, c := range currentSecrets {
 			if !containsSecret(c, desiredSecrets) {
@@ -61,7 +60,7 @@ func (r *Resource) newDeleteChangeForUpdatePatch(ctx context.Context, obj, curre
 			}
 		}
 
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("computed %d Secrets to delete", len(secretsToDelete)))
+		r.logger.Debugf(ctx, "computed %d Secrets to delete", len(secretsToDelete))
 	}
 
 	return secretsToDelete, nil

--- a/pkg/resource/k8s/secretresource/update.go
+++ b/pkg/resource/k8s/secretresource/update.go
@@ -2,7 +2,6 @@ package secretresource
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/giantswarm/microerror"
 	corev1 "k8s.io/api/core/v1"
@@ -16,14 +15,14 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 	}
 
 	for _, secret := range secrets {
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("updating Secret %#q in namespace %#q", secret.Name, secret.Namespace))
+		r.logger.Debugf(ctx, "updating Secret %#q in namespace %#q", secret.Name, secret.Namespace)
 
 		_, err = r.k8sClient.CoreV1().Secrets(secret.Namespace).Update(ctx, secret, metav1.UpdateOptions{})
 		if err != nil {
 			return microerror.Mask(err)
 		}
 
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("updated Secret %#q in namespace %#q", secret.Name, secret.Namespace))
+		r.logger.Debugf(ctx, "updated Secret %#q in namespace %#q", secret.Name, secret.Namespace)
 	}
 
 	return nil
@@ -41,7 +40,7 @@ func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desir
 
 	var secretsToUpdate []*corev1.Secret
 	{
-		r.logger.LogCtx(ctx, "level", "debug", "message", "computing Secrets to update")
+		r.logger.Debugf(ctx, "computing Secrets to update")
 
 		for _, c := range currentSecrets {
 			for _, d := range desiredSecrets {
@@ -52,7 +51,7 @@ func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desir
 			}
 		}
 
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("computed %d Secrets to update", len(secretsToUpdate)))
+		r.logger.Debugf(ctx, "computed %d Secrets to update", len(secretsToUpdate))
 	}
 
 	return secretsToUpdate, nil

--- a/pkg/resource/wrapper/retryresource/basic_resource.go
+++ b/pkg/resource/wrapper/retryresource/basic_resource.go
@@ -56,7 +56,7 @@ func (r *basicResource) EnsureCreated(ctx context.Context, obj interface{}) erro
 	}
 
 	n := func(err error, dur time.Duration) {
-		r.logger.LogCtx(ctx, "level", "warning", "message", "retrying due to error", "stack", microerror.JSON(err))
+		r.logger.Errorf(ctx, err, "retrying due to error")
 	}
 
 	err = backoff.RetryNotify(o, r.backOff, n)
@@ -80,7 +80,7 @@ func (r *basicResource) EnsureDeleted(ctx context.Context, obj interface{}) erro
 	}
 
 	n := func(err error, dur time.Duration) {
-		r.logger.LogCtx(ctx, "level", "warning", "message", "retrying due to error", "stack", microerror.JSON(err))
+		r.logger.Errorf(ctx, err, "retrying due to error")
 	}
 
 	err = backoff.RetryNotify(o, r.backOff, n)

--- a/pkg/resource/wrapper/retryresource/crud_resource.go
+++ b/pkg/resource/wrapper/retryresource/crud_resource.go
@@ -61,7 +61,7 @@ func (r *crudResource) GetCurrentState(ctx context.Context, obj interface{}) (in
 	}
 
 	n := func(err error, dur time.Duration) {
-		r.logger.LogCtx(ctx, "level", "warning", "message", "retrying due to error", "stack", microerror.JSON(err))
+		r.logger.Errorf(ctx, err, "retrying due to error")
 	}
 
 	err = backoff.RetryNotify(o, r.backOff, n)
@@ -86,7 +86,7 @@ func (r *crudResource) GetDesiredState(ctx context.Context, obj interface{}) (in
 	}
 
 	n := func(err error, dur time.Duration) {
-		r.logger.LogCtx(ctx, "level", "warning", "message", "retrying due to error", "stack", microerror.JSON(err))
+		r.logger.Errorf(ctx, err, "retrying due to error")
 	}
 
 	err = backoff.RetryNotify(o, r.backOff, n)
@@ -111,7 +111,7 @@ func (r *crudResource) NewUpdatePatch(ctx context.Context, obj, currentState, de
 	}
 
 	n := func(err error, dur time.Duration) {
-		r.logger.LogCtx(ctx, "level", "warning", "message", "retrying due to error", "stack", microerror.JSON(err))
+		r.logger.Errorf(ctx, err, "retrying due to error")
 	}
 
 	err = backoff.RetryNotify(o, r.backOff, n)
@@ -136,7 +136,7 @@ func (r *crudResource) NewDeletePatch(ctx context.Context, obj, currentState, de
 	}
 
 	n := func(err error, dur time.Duration) {
-		r.logger.LogCtx(ctx, "level", "warning", "message", "retrying due to error", "stack", microerror.JSON(err))
+		r.logger.Errorf(ctx, err, "retrying due to error")
 	}
 
 	err = backoff.RetryNotify(o, r.backOff, n)
@@ -158,7 +158,7 @@ func (r *crudResource) ApplyCreateChange(ctx context.Context, obj, createState i
 	}
 
 	n := func(err error, dur time.Duration) {
-		r.logger.LogCtx(ctx, "level", "warning", "message", "retrying due to error", "stack", microerror.JSON(err))
+		r.logger.Errorf(ctx, err, "retrying due to error")
 	}
 
 	err := backoff.RetryNotify(o, r.backOff, n)
@@ -180,7 +180,7 @@ func (r *crudResource) ApplyDeleteChange(ctx context.Context, obj, deleteState i
 	}
 
 	n := func(err error, dur time.Duration) {
-		r.logger.LogCtx(ctx, "level", "warning", "message", "retrying due to error", "stack", microerror.JSON(err))
+		r.logger.Errorf(ctx, err, "retrying due to error")
 	}
 
 	err := backoff.RetryNotify(o, r.backOff, n)
@@ -202,7 +202,7 @@ func (r *crudResource) ApplyUpdateChange(ctx context.Context, obj, updateState i
 	}
 
 	n := func(err error, dur time.Duration) {
-		r.logger.LogCtx(ctx, "level", "warning", "message", "retrying due to error", "stack", microerror.JSON(err))
+		r.logger.Errorf(ctx, err, "retrying due to error")
 	}
 
 	err := backoff.RetryNotify(o, r.backOff, n)


### PR DESCRIPTION
Changed using this script:

```
devctl replace -i \
    'LogCtx\(ctx, "level", "debug", "message", fmt.Sprintf\((.*)\)\)' \
    'Debugf(ctx, $1)'\
    '**/*.go'

devctl replace -i \
    'LogCtx\(ctx, "level", "debug", "message", "(.*)"\)' \
    'Debugf(ctx, "$1")'\
    '**/*.go'

devctl replace -i \
    'LogCtx\(ctx, "level", "error", "message", "fmt.Sprintf\((.*)\)", "stack", microerror.JSON\(err\)\)' \
    'Errorf(ctx, err, $1)'\
    '**/*.go'

devctl replace -i \
    'LogCtx\(ctx, "level", "error", "message", "(.*)", "stack", microerror.JSON\(err\)\)' \
    'Errorf(ctx, err, "$1")'\
    '**/*.go'

devctl replace -i \
    'r.logger.LogCtx\(ctx, "level", "warning", "message", "retrying due to error", "stack", microerror.JSON\(err\)\)' \
    'r.logger.Errorf(ctx, err, "retrying due to error")' \
    '**/*.go'

goimports -local github.com/giantswarm/operatorkit -w .
```

Note that:

```go
r.logger.LogCtx(ctx, "level", "warning", "message", "retrying due to error", "stack", microerror.JSON(err))
```

was replaced with:

```go
r.logger.Errorf(ctx, err, "retrying due to error")
```

There are no other changes to the output.