### PR TITLE
Change `operatorkit_controller_error_total` metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Change `operatorkit_controller_error_total` from gauge to counter and provide
+  labels for CR name and when available, cluster ID and release version. Third
+  party errors caught by controller-runtime error handler are not counted anymore.
+
 ### Added
 
 - Add `namespace` into controller setting.
 
 ### Fixed
 
-- Propagate label selectors to timestamp collector
+- Propagate label selectors to timestamp collector.
 
 ## [4.0.0] - 2020-10-27
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -307,7 +307,7 @@ func (c *Controller) Reconcile(req reconcile.Request) (reconcile.Result, error) 
 	if err != nil {
 		// Microerror creates an error event on the object when kind and description is set.
 		c.event.Emit(ctx, obj, err)
-		errorGauge.Inc()
+		errorCounterVec.With(errorMetricLabels(obj)).Inc()
 		c.sentry.Capture(ctx, err)
 		c.logger.Errorf(ctx, err, "failed to reconcile")
 		return reconcile.Result{}, nil
@@ -329,7 +329,6 @@ func (c *Controller) bootWithError(ctx context.Context) error {
 		for {
 			resetWait := c.resyncPeriod * 4
 			time.Sleep(resetWait)
-			errorGauge.Set(0)
 		}
 	}()
 
@@ -348,7 +347,6 @@ func (c *Controller) bootWithError(ctx context.Context) error {
 					return
 				}
 
-				errorGauge.Inc()
 				c.logger.Errorf(ctx, err, "caught third party runtime error")
 			},
 		}

--- a/pkg/controller/metric.go
+++ b/pkg/controller/metric.go
@@ -19,7 +19,7 @@ var (
 			Name:      "error_total",
 			Help:      "Number of reconciliation errors.",
 		},
-		[]string{"cr_name", "cluster_id", "release_version"},
+		[]string{"cr_name", "cr_kind", "cluster_id", "release_version"},
 	)
 	eventHistogram = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{

--- a/pkg/controller/metric.go
+++ b/pkg/controller/metric.go
@@ -2,6 +2,8 @@ package controller
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 const (
@@ -10,13 +12,14 @@ const (
 )
 
 var (
-	errorGauge = prometheus.NewGauge(
-		prometheus.GaugeOpts{
+	errorCounterVec = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
 			Namespace: PrometheusNamespace,
 			Subsystem: PrometheusSubsystem,
 			Name:      "error_total",
 			Help:      "Number of reconciliation errors.",
 		},
+		[]string{"cr_name", "cluster_id", "release_version"},
 	)
 	eventHistogram = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
@@ -30,6 +33,33 @@ var (
 )
 
 func init() {
-	prometheus.MustRegister(errorGauge)
+	prometheus.MustRegister(errorCounterVec)
 	prometheus.MustRegister(eventHistogram)
+}
+
+func errorMetricLabels(obj runtime.Object) prometheus.Labels {
+	labels := make(map[string]string)
+
+	m, err := meta.Accessor(obj)
+	if err != nil {
+		return labels
+	}
+
+	labels["cr_name"] = m.GetName()
+
+	if v, exists := m.GetLabels()["cluster.x-k8s.io/cluster-name"]; exists {
+		labels["cluster_id"] = v
+	} else if v, exists := m.GetLabels()["giantswarm.io/cluster"]; exists {
+		labels["cluster_id"] = v
+	} else {
+		labels["cluster_id"] = ""
+	}
+
+	if v, exists := m.GetLabels()["release.giantswarm.io/version"]; exists {
+		labels["release_version"] = v
+	} else {
+		labels["release_version"] = ""
+	}
+
+	return labels
 }

--- a/pkg/controller/metric.go
+++ b/pkg/controller/metric.go
@@ -40,11 +40,17 @@ func init() {
 func errorMetricLabels(obj runtime.Object) prometheus.Labels {
 	labels := make(map[string]string)
 
+	t, err := meta.TypeAccessor(obj)
+	if err != nil {
+		return labels
+	}
+
 	m, err := meta.Accessor(obj)
 	if err != nil {
 		return labels
 	}
 
+	labels["cr_kind"] = t.GetKind()
 	labels["cr_name"] = m.GetName()
 
 	if v, exists := m.GetLabels()["cluster.x-k8s.io/cluster-name"]; exists {


### PR DESCRIPTION
Change `operatorkit_controller_error_total` from gauge to counter and
provide labels for CR name and when available, cluster ID and release
version. Third party errors caught by `controller-runtime` error handler
are not counted anymore.

## Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Update roadmap in ROADMAP.md.
