### PR TITLE
Expose settings for sentry client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `namespace` into controller setting.
+- Add `SentryTags` Config field to allow setting custom tags to be sent alongside errors to `sentry.io`.
 
 ### Fixed
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/signal"
@@ -310,7 +311,8 @@ func (c *Controller) Reconcile(req reconcile.Request) (reconcile.Result, error) 
 	res, err := c.reconcile(ctx, req, obj)
 	if err != nil {
 		fmt.Println("=========================")
-		fmt.Println(err)
+		j, _ := json.Marshal(err)
+		fmt.Println(string(j))
 		fmt.Println("=========================")
 
 		// Microerror creates an error event on the object when kind and description is set.

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -2,7 +2,6 @@ package controller
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 	"os/signal"
@@ -310,11 +309,6 @@ func (c *Controller) Reconcile(req reconcile.Request) (reconcile.Result, error) 
 
 	res, err := c.reconcile(ctx, req, obj)
 	if err != nil {
-		fmt.Println("=========================")
-		j, _ := json.Marshal(err)
-		fmt.Println(string(j))
-		fmt.Println("=========================")
-
 		// Microerror creates an error event on the object when kind and description is set.
 		c.event.Emit(ctx, obj, err)
 		errorGauge.Inc()

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -111,7 +111,7 @@ type Config struct {
 	// SentryDSN is the optional URL used to forward runtime errors to the sentry.io service.
 	// If this field is empty, logs will not be forwarded.
 	SentryDSN string
-	// SentryTag is an optional map that allows to specify key-value pairs to be be sent alongside
+	// SentryTags is an optional map that allows to specify key-value pairs to be be sent alongside
 	// errors to the sentry.io service.
 	SentryTags map[string]string
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -110,7 +110,10 @@ type Config struct {
 	ResyncPeriod time.Duration
 	// SentryDSN is the optional URL used to forward runtime errors to the sentry.io service.
 	// If this field is empty, logs will not be forwarded.
-	SentryConfig *sentry.Config
+	SentryDSN string
+	// SentryTag is an optional map that allows to specify key-value pairs to be be sent alongside
+	// errors to the sentry.io service.
+	SentryTags map[string]string
 }
 
 type Controller struct {
@@ -206,7 +209,12 @@ func New(config Config) (*Controller, error) {
 
 	var sentryClient sentry.Interface
 	{
-		sentryClient, err = sentry.New(config.SentryConfig)
+		c := sentry.Config{
+			DSN:  config.SentryDSN,
+			Tags: config.SentryTags,
+		}
+
+		sentryClient, err = sentry.New(c)
 		if err != nil {
 			// Error during sentry initialization.
 			return nil, microerror.Mask(err)

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -110,7 +110,7 @@ type Config struct {
 	ResyncPeriod time.Duration
 	// SentryDSN is the optional URL used to forward runtime errors to the sentry.io service.
 	// If this field is empty, logs will not be forwarded.
-	SentryDSN string
+	SentryConfig *sentry.Config
 }
 
 type Controller struct {
@@ -206,11 +206,7 @@ func New(config Config) (*Controller, error) {
 
 	var sentryClient sentry.Interface
 	{
-		c := sentry.Config{
-			DSN: config.SentryDSN,
-		}
-
-		sentryClient, err = sentry.New(c)
+		sentryClient, err = sentry.New(config.SentryConfig)
 		if err != nil {
 			// Error during sentry initialization.
 			return nil, microerror.Mask(err)

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -309,10 +309,10 @@ func (c *Controller) Reconcile(req reconcile.Request) (reconcile.Result, error) 
 
 	res, err := c.reconcile(ctx, req, obj)
 	if err != nil {
+		c.sentry.Capture(ctx, err)
 		// Microerror creates an error event on the object when kind and description is set.
 		c.event.Emit(ctx, obj, err)
 		errorGauge.Inc()
-		c.sentry.Capture(ctx, err)
 		c.logger.Errorf(ctx, err, "failed to reconcile")
 		return reconcile.Result{}, nil
 	}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -309,10 +309,14 @@ func (c *Controller) Reconcile(req reconcile.Request) (reconcile.Result, error) 
 
 	res, err := c.reconcile(ctx, req, obj)
 	if err != nil {
-		c.sentry.Capture(ctx, err)
+		fmt.Println("=========================")
+		fmt.Println(err)
+		fmt.Println("=========================")
+
 		// Microerror creates an error event on the object when kind and description is set.
 		c.event.Emit(ctx, obj, err)
 		errorGauge.Inc()
+		c.sentry.Capture(ctx, err)
 		c.logger.Errorf(ctx, err, "failed to reconcile")
 		return reconcile.Result{}, nil
 	}

--- a/pkg/controller/internal/sentry/default.go
+++ b/pkg/controller/internal/sentry/default.go
@@ -4,11 +4,12 @@ import (
 	"context"
 
 	"github.com/getsentry/sentry-go"
+	"github.com/giantswarm/microerror"
 )
 
 type Default struct {
 }
 
 func (s *Default) Capture(ctx context.Context, err error) {
-	sentry.CaptureException(err)
+	sentry.CaptureException(microerror.Mask(err))
 }

--- a/pkg/controller/internal/sentry/default.go
+++ b/pkg/controller/internal/sentry/default.go
@@ -28,6 +28,7 @@ func extractReflectedStacktraceMethod(err error) reflect.Value {
 	methodStackFrames := reflect.ValueOf(err).MethodByName("StackFrames")
 
 	if methodGetStackTracer.IsValid() {
+		fmt.Println("methodGetStackTracer")
 		stacktracer := methodGetStackTracer.Call(make([]reflect.Value, 0))[0]
 		stacktracerStackTrace := reflect.ValueOf(stacktracer).MethodByName("StackTrace")
 
@@ -37,10 +38,12 @@ func extractReflectedStacktraceMethod(err error) reflect.Value {
 	}
 
 	if methodStackTrace.IsValid() {
+		fmt.Println("methodStackTrace")
 		method = methodStackTrace
 	}
 
 	if methodStackFrames.IsValid() {
+		fmt.Println("methodStackFrames")
 		method = methodStackFrames
 	}
 

--- a/pkg/controller/internal/sentry/default.go
+++ b/pkg/controller/internal/sentry/default.go
@@ -2,6 +2,8 @@ package sentry
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 
 	"github.com/getsentry/sentry-go"
 )
@@ -10,5 +12,9 @@ type Default struct {
 }
 
 func (s *Default) Capture(ctx context.Context, err error) {
+	fmt.Println("=========================")
+	j, _ := json.Marshal(err)
+	fmt.Println(string(j))
+	fmt.Println("=========================")
 	sentry.CaptureException(err)
 }

--- a/pkg/controller/internal/sentry/default.go
+++ b/pkg/controller/internal/sentry/default.go
@@ -2,8 +2,8 @@ package sentry
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
+	"reflect"
 
 	"github.com/getsentry/sentry-go"
 )
@@ -12,9 +12,6 @@ type Default struct {
 }
 
 func (s *Default) Capture(ctx context.Context, err error) {
-	fmt.Println("-------------------------")
-	j, _ := json.Marshal(err)
-	fmt.Println(string(j))
-	fmt.Println("-------------------------")
+	fmt.Printf("type: %s\n", reflect.TypeOf(err).String())
 	sentry.CaptureException(err)
 }

--- a/pkg/controller/internal/sentry/default.go
+++ b/pkg/controller/internal/sentry/default.go
@@ -12,6 +12,37 @@ type Default struct {
 }
 
 func (s *Default) Capture(ctx context.Context, err error) {
-	fmt.Printf("type: %s\n", reflect.TypeOf(err).String())
+	method := extractReflectedStacktraceMethod(err)
+	fmt.Printf("valid: %t, name: %s\n", method.IsValid(), method.String())
 	sentry.CaptureException(err)
+}
+
+func extractReflectedStacktraceMethod(err error) reflect.Value {
+	var method reflect.Value
+
+	// https://github.com/pingcap/errors
+	methodGetStackTracer := reflect.ValueOf(err).MethodByName("GetStackTracer")
+	// https://github.com/pkg/errors
+	methodStackTrace := reflect.ValueOf(err).MethodByName("StackTrace")
+	// https://github.com/go-errors/errors
+	methodStackFrames := reflect.ValueOf(err).MethodByName("StackFrames")
+
+	if methodGetStackTracer.IsValid() {
+		stacktracer := methodGetStackTracer.Call(make([]reflect.Value, 0))[0]
+		stacktracerStackTrace := reflect.ValueOf(stacktracer).MethodByName("StackTrace")
+
+		if stacktracerStackTrace.IsValid() {
+			method = stacktracerStackTrace
+		}
+	}
+
+	if methodStackTrace.IsValid() {
+		method = methodStackTrace
+	}
+
+	if methodStackFrames.IsValid() {
+		method = methodStackFrames
+	}
+
+	return method
 }

--- a/pkg/controller/internal/sentry/default.go
+++ b/pkg/controller/internal/sentry/default.go
@@ -2,9 +2,6 @@ package sentry
 
 import (
 	"context"
-	"fmt"
-	"reflect"
-	"runtime"
 
 	"github.com/getsentry/sentry-go"
 )
@@ -13,93 +10,5 @@ type Default struct {
 }
 
 func (s *Default) Capture(ctx context.Context, err error) {
-	method := extractReflectedStacktraceMethod(err)
-	pcs := extractPcs(method)
-	fmt.Println(pcs)
-	_ = extractFrames(pcs)
-
 	sentry.CaptureException(err)
-}
-
-func extractFrames(pcs []uintptr) []sentry.Frame {
-	var frames []sentry.Frame
-	callersFrames := runtime.CallersFrames(pcs)
-
-	for {
-		callerFrame, more := callersFrames.Next()
-
-		fmt.Printf("pc = %d, file = %s, line = %d\n", callerFrame.PC, callerFrame.File, callerFrame.Line)
-
-		frames = append([]sentry.Frame{
-			sentry.NewFrame(callerFrame),
-		}, frames...)
-
-		if !more {
-			break
-		}
-	}
-
-	return frames
-}
-
-func extractPcs(method reflect.Value) []uintptr {
-	var pcs []uintptr
-
-	stacktrace := method.Call(make([]reflect.Value, 0))[0]
-
-	if stacktrace.Kind() != reflect.Slice {
-		return nil
-	}
-
-	for i := 0; i < stacktrace.Len(); i++ {
-		pc := stacktrace.Index(i)
-
-		if pc.Kind() == reflect.Uintptr {
-			pcs = append(pcs, uintptr(pc.Uint()))
-			continue
-		}
-
-		if pc.Kind() == reflect.Struct {
-			field := pc.FieldByName("ProgramCounter")
-			if field.IsValid() && field.Kind() == reflect.Uintptr {
-				pcs = append(pcs, uintptr(field.Uint()))
-				continue
-			}
-		}
-	}
-
-	return pcs
-}
-
-func extractReflectedStacktraceMethod(err error) reflect.Value {
-	var method reflect.Value
-
-	// https://github.com/pingcap/errors
-	methodGetStackTracer := reflect.ValueOf(err).MethodByName("GetStackTracer")
-	// https://github.com/pkg/errors
-	methodStackTrace := reflect.ValueOf(err).MethodByName("StackTrace")
-	// https://github.com/go-errors/errors
-	methodStackFrames := reflect.ValueOf(err).MethodByName("StackFrames")
-
-	if methodGetStackTracer.IsValid() {
-		fmt.Println("methodGetStackTracer")
-		stacktracer := methodGetStackTracer.Call(make([]reflect.Value, 0))[0]
-		stacktracerStackTrace := reflect.ValueOf(stacktracer).MethodByName("StackTrace")
-
-		if stacktracerStackTrace.IsValid() {
-			method = stacktracerStackTrace
-		}
-	}
-
-	if methodStackTrace.IsValid() {
-		fmt.Println("methodStackTrace")
-		method = methodStackTrace
-	}
-
-	if methodStackFrames.IsValid() {
-		fmt.Println("methodStackFrames")
-		method = methodStackFrames
-	}
-
-	return method
 }

--- a/pkg/controller/internal/sentry/default.go
+++ b/pkg/controller/internal/sentry/default.go
@@ -16,8 +16,7 @@ func (s *Default) Capture(ctx context.Context, err error) {
 	method := extractReflectedStacktraceMethod(err)
 	pcs := extractPcs(method)
 	fmt.Println(pcs)
-	frames := extractFrames(pcs)
-	fmt.Println(frames)
+	_ = extractFrames(pcs)
 
 	sentry.CaptureException(err)
 }
@@ -28,6 +27,8 @@ func extractFrames(pcs []uintptr) []sentry.Frame {
 
 	for {
 		callerFrame, more := callersFrames.Next()
+
+		fmt.Printf("pc = %d, file = %s, line = %d\n", callerFrame.PC, callerFrame.File, callerFrame.Line)
 
 		frames = append([]sentry.Frame{
 			sentry.NewFrame(callerFrame),

--- a/pkg/controller/internal/sentry/default.go
+++ b/pkg/controller/internal/sentry/default.go
@@ -4,13 +4,11 @@ import (
 	"context"
 
 	"github.com/getsentry/sentry-go"
-	"github.com/giantswarm/microerror"
 )
 
 type Default struct {
 }
 
 func (s *Default) Capture(ctx context.Context, err error) {
-	sentry.CaptureException(microerror.Mask(err))
 	sentry.CaptureException(err)
 }

--- a/pkg/controller/internal/sentry/default.go
+++ b/pkg/controller/internal/sentry/default.go
@@ -12,4 +12,5 @@ type Default struct {
 
 func (s *Default) Capture(ctx context.Context, err error) {
 	sentry.CaptureException(microerror.Mask(err))
+	sentry.CaptureException(err)
 }

--- a/pkg/controller/internal/sentry/default.go
+++ b/pkg/controller/internal/sentry/default.go
@@ -12,9 +12,9 @@ type Default struct {
 }
 
 func (s *Default) Capture(ctx context.Context, err error) {
-	fmt.Println("=========================")
+	fmt.Println("-------------------------")
 	j, _ := json.Marshal(err)
 	fmt.Println(string(j))
-	fmt.Println("=========================")
+	fmt.Println("-------------------------")
 	sentry.CaptureException(err)
 }

--- a/pkg/controller/internal/sentry/service.go
+++ b/pkg/controller/internal/sentry/service.go
@@ -10,8 +10,8 @@ type Config struct {
 	Tags map[string]string
 }
 
-func New(config *Config) (Interface, error) {
-	if config == nil || config.DSN == "" {
+func New(config Config) (Interface, error) {
+	if config.DSN == "" {
 		return &Disabled{}, nil
 	}
 	err := sentry.Init(sentry.ClientOptions{

--- a/pkg/controller/internal/sentry/service.go
+++ b/pkg/controller/internal/sentry/service.go
@@ -6,11 +6,12 @@ import (
 )
 
 type Config struct {
-	DSN string
+	DSN  string
+	Tags map[string]string
 }
 
-func New(config Config) (Interface, error) {
-	if config.DSN == "" {
+func New(config *Config) (Interface, error) {
+	if config == nil || config.DSN == "" {
 		return &Disabled{}, nil
 	}
 	err := sentry.Init(sentry.ClientOptions{
@@ -18,6 +19,14 @@ func New(config Config) (Interface, error) {
 	})
 	if err != nil {
 		return nil, microerror.Mask(err)
+	}
+
+	if len(config.Tags) > 0 {
+		sentry.ConfigureScope(func(scope *sentry.Scope) {
+			for k, v := range config.Tags {
+				scope.SetTag(k, v)
+			}
+		})
 	}
 
 	return &Default{}, nil

--- a/pkg/controller/internal/sentry/service.go
+++ b/pkg/controller/internal/sentry/service.go
@@ -15,8 +15,7 @@ func New(config Config) (Interface, error) {
 		return &Disabled{}, nil
 	}
 	err := sentry.Init(sentry.ClientOptions{
-		Dsn:   config.DSN,
-		Debug: true,
+		Dsn: config.DSN,
 	})
 	if err != nil {
 		return nil, microerror.Mask(err)

--- a/pkg/controller/internal/sentry/service.go
+++ b/pkg/controller/internal/sentry/service.go
@@ -15,7 +15,8 @@ func New(config Config) (Interface, error) {
 		return &Disabled{}, nil
 	}
 	err := sentry.Init(sentry.ClientOptions{
-		Dsn: config.DSN,
+		Dsn:   config.DSN,
+		Debug: true,
 	})
 	if err != nil {
 		return nil, microerror.Mask(err)


### PR DESCRIPTION
Added `SentryTags` Config field to allow setting custom tags to be sent alongside errors to `sentry.io`.