### PR TITLE
Make finalizer cache TTL configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Make removed finalizer cache TTL configurable.
+
 ## [4.1.0] - 2020-12-18
 
 ### Added
 
 - Add `namespace` into controller setting.
-- Make removed finalizer cache TTL configurable.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `namespace` into controller setting.
+- Make removed finalizer cache TTL configurable.
 
 ### Fixed
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/14666

This is to fix a problem when using app-operator with tests run by app-build-suite. On the 1st run the tests pass but on later runs the tests fail because the deletion logic is not executed.

This makes the TTL configurable so we can use a short timeout when app-operator is installed via apptestctl. Otherwise we keep the current TTL of 3 times the resync period.

## Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Update roadmap in ROADMAP.md.
