### PR TITLE
Re-expose NewSelector in controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Re-expose `controller.NewSelector()`.
+
 ## [4.2.0] - 2021-01-07
 
 ### Added

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	pkgruntime "k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -273,6 +274,10 @@ func (c *Controller) Boot(ctx context.Context) {
 
 func (c *Controller) Booted() chan struct{} {
 	return c.booted
+}
+
+func NewSelector(matchesFunc func(labels labels.Labels) bool) selector.Selector {
+	return selector.NewSelector(matchesFunc)
 }
 
 // Reconcile implements the reconciler given to the controller-runtime


### PR DESCRIPTION
This was moved in https://github.com/giantswarm/operatorkit/pull/496 in order to remove a circular dependency, but some external callers still rely on it.

- [x] Update changelog in CHANGELOG.md.
- [ ] Update roadmap in ROADMAP.md.
