### PR TITLE
Add AllowedLabels to configmap resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Re-expose `controller.NewSelector()`.
 - Only close manager channel once.
+- Add `AllowedLabels` to configmap resource to prevent unnecessary updates.
 
 ## [4.2.0] - 2021-01-07
 

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/giantswarm/microerror v0.3.0
 	github.com/giantswarm/micrologger v0.5.0
 	github.com/giantswarm/to v0.3.0
-	github.com/google/go-cmp v0.5.4
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/prometheus/client_golang v1.9.0
 	k8s.io/api v0.18.9

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/giantswarm/microerror v0.3.0
 	github.com/giantswarm/micrologger v0.5.0
 	github.com/giantswarm/to v0.3.0
+	github.com/google/go-cmp v0.5.4
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/prometheus/client_golang v1.9.0
 	k8s.io/api v0.18.9

--- a/go.sum
+++ b/go.sum
@@ -746,7 +746,6 @@ golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e h1:vcxGaoTs7kV8m5Np9uUNQin4BrLOthgV7252N8V+FwY=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a h1:DcqTD9SDLc+1P/r1EmRBwnVsrOwW+kk2vWf9n+1sGhs=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/pkg/resource/k8s/configmapresource/new_config_map_to_update.go
+++ b/pkg/resource/k8s/configmapresource/new_config_map_to_update.go
@@ -1,8 +1,10 @@
 package configmapresource
 
 import (
+	"fmt"
 	"reflect"
 
+	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -39,6 +41,9 @@ func newConfigMapToUpdate(current, desired *corev1.ConfigMap, allowedLabels map[
 
 	merged.BinaryData = desired.BinaryData
 	merged.Data = desired.Data
+
+	diff := cmp.Diff(current, merged)
+	fmt.Printf("CONFIGMAP DIFF\n%s\n", diff)
 
 	if reflect.DeepEqual(current, merged) {
 		return nil

--- a/pkg/resource/k8s/configmapresource/new_config_map_to_update.go
+++ b/pkg/resource/k8s/configmapresource/new_config_map_to_update.go
@@ -30,7 +30,7 @@ func newConfigMapToUpdate(current, desired *corev1.ConfigMap, allowedLabels map[
 				continue
 			}
 
-			if _, ok := allowedLabels[k]; ok {
+			if allowedLabels[k] {
 				merged.Labels[k] = v
 			}
 		}

--- a/pkg/resource/k8s/configmapresource/new_config_map_to_update.go
+++ b/pkg/resource/k8s/configmapresource/new_config_map_to_update.go
@@ -27,7 +27,7 @@ func newConfigMapToUpdate(current, desired *corev1.ConfigMap, allowedLabels map[
 	if allowedLabels != nil {
 		for k, v := range current.Labels {
 			if _, exist := desired.Labels[k]; exist {
-				// if annotation is already in desired spec, skip it.
+				// If label is already in desired spec, skip it.
 				continue
 			}
 

--- a/pkg/resource/k8s/configmapresource/new_config_map_to_update.go
+++ b/pkg/resource/k8s/configmapresource/new_config_map_to_update.go
@@ -1,10 +1,8 @@
 package configmapresource
 
 import (
-	"fmt"
 	"reflect"
 
-	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -40,9 +38,6 @@ func newConfigMapToUpdate(current, desired *corev1.ConfigMap, allowedLabels map[
 
 	merged.BinaryData = desired.BinaryData
 	merged.Data = desired.Data
-
-	diff := cmp.Diff(current, merged)
-	fmt.Printf("CONFIGMAP DIFF\n%s\n", diff)
 
 	if reflect.DeepEqual(current, merged) {
 		return nil

--- a/pkg/resource/k8s/configmapresource/new_config_map_to_update.go
+++ b/pkg/resource/k8s/configmapresource/new_config_map_to_update.go
@@ -23,6 +23,7 @@ func newConfigMapToUpdate(current, desired *corev1.ConfigMap, allowedLabels map[
 	merged := current.DeepCopy()
 
 	merged.Annotations = desired.Annotations
+	merged.Labels = desired.Labels
 
 	if allowedLabels != nil {
 		for k, v := range current.Labels {
@@ -36,8 +37,6 @@ func newConfigMapToUpdate(current, desired *corev1.ConfigMap, allowedLabels map[
 			}
 		}
 	}
-
-	merged.Labels = desired.Labels
 
 	merged.BinaryData = desired.BinaryData
 	merged.Data = desired.Data

--- a/pkg/resource/k8s/configmapresource/new_config_map_to_update.go
+++ b/pkg/resource/k8s/configmapresource/new_config_map_to_update.go
@@ -10,7 +10,7 @@ import (
 // argument to Update method of generated client. It returns nil if the name or
 // namespace doesn't match or if objects don't have differences in scope of
 // interest.
-func newConfigMapToUpdate(current, desired *corev1.ConfigMap) *corev1.ConfigMap {
+func newConfigMapToUpdate(current, desired *corev1.ConfigMap, allowedLabels map[string]bool) *corev1.ConfigMap {
 	if current.Namespace != desired.Namespace {
 		return nil
 	}
@@ -21,6 +21,20 @@ func newConfigMapToUpdate(current, desired *corev1.ConfigMap) *corev1.ConfigMap 
 	merged := current.DeepCopy()
 
 	merged.Annotations = desired.Annotations
+
+	if allowedLabels != nil {
+		for k, v := range current.Labels {
+			if _, exist := desired.Labels[k]; exist {
+				// if annotation is already in desired spec, skip it.
+				continue
+			}
+
+			if _, ok := allowedLabels[k]; ok {
+				merged.Labels[k] = v
+			}
+		}
+	}
+
 	merged.Labels = desired.Labels
 
 	merged.BinaryData = desired.BinaryData

--- a/pkg/resource/k8s/configmapresource/resource.go
+++ b/pkg/resource/k8s/configmapresource/resource.go
@@ -12,7 +12,8 @@ type Config struct {
 	Logger      micrologger.Logger
 	StateGetter StateGetter
 
-	Name string
+	AllowedLabels []string
+	Name          string
 }
 
 type Resource struct {
@@ -20,7 +21,8 @@ type Resource struct {
 	logger      micrologger.Logger
 	stateGetter StateGetter
 
-	name string
+	allowedLabels map[string]bool
+	name          string
 }
 
 func New(config Config) (*Resource, error) {
@@ -44,6 +46,17 @@ func New(config Config) (*Resource, error) {
 		stateGetter: config.StateGetter,
 
 		name: config.Name,
+	}
+
+	if config.AllowedLabels != nil {
+		allowedLabels := map[string]bool{}
+		{
+			for _, label := range config.AllowedLabels {
+				allowedLabels[label] = true
+			}
+		}
+
+		r.allowedLabels = allowedLabels
 	}
 
 	return r, nil

--- a/pkg/resource/k8s/configmapresource/update.go
+++ b/pkg/resource/k8s/configmapresource/update.go
@@ -44,7 +44,7 @@ func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desir
 
 		for _, c := range currentConfigMaps {
 			for _, d := range desiredConfigMaps {
-				m := newConfigMapToUpdate(c, d)
+				m := newConfigMapToUpdate(c, d, r.allowedLabels)
 				if m != nil {
 					configMapsToUpdate = append(configMapsToUpdate, m)
 				}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/14163

Extends the generic configmap resource to configure a list of allowed labels.

This is needed in the clusterconfigmap in cluster-operator because the configmap includes the label below which is added by app-operator so it can watch for changes.

```
labels:
  app-operator.giantswarm.io/watching: "true"
```

## Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Update roadmap in ROADMAP.md.
