### PR TITLE
prepare v7 release

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/giantswarm/operatorkit/v6
+module github.com/giantswarm/operatorkit/v7
 
 go 1.17
 

--- a/integration/test/basic/basic_test.go
+++ b/integration/test/basic/basic_test.go
@@ -14,9 +14,9 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	"github.com/giantswarm/operatorkit/v6/integration/testresource"
-	"github.com/giantswarm/operatorkit/v6/integration/wrapper/configmap"
-	"github.com/giantswarm/operatorkit/v6/pkg/resource"
+	"github.com/giantswarm/operatorkit/v7/integration/testresource"
+	"github.com/giantswarm/operatorkit/v7/integration/wrapper/configmap"
+	"github.com/giantswarm/operatorkit/v7/pkg/resource"
 )
 
 const (

--- a/integration/test/controlflow/controlflow_test.go
+++ b/integration/test/controlflow/controlflow_test.go
@@ -15,10 +15,10 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/operatorkit/v6/integration/testresource"
-	"github.com/giantswarm/operatorkit/v6/integration/wrapper"
-	"github.com/giantswarm/operatorkit/v6/integration/wrapper/configmap"
-	"github.com/giantswarm/operatorkit/v6/pkg/resource"
+	"github.com/giantswarm/operatorkit/v7/integration/testresource"
+	"github.com/giantswarm/operatorkit/v7/integration/wrapper"
+	"github.com/giantswarm/operatorkit/v7/integration/wrapper/configmap"
+	"github.com/giantswarm/operatorkit/v7/pkg/resource"
 )
 
 const (

--- a/integration/test/error/error_test.go
+++ b/integration/test/error/error_test.go
@@ -14,9 +14,9 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/operatorkit/v6/integration/testresource"
-	"github.com/giantswarm/operatorkit/v6/integration/wrapper/configmap"
-	"github.com/giantswarm/operatorkit/v6/pkg/resource"
+	"github.com/giantswarm/operatorkit/v7/integration/testresource"
+	"github.com/giantswarm/operatorkit/v7/integration/wrapper/configmap"
+	"github.com/giantswarm/operatorkit/v7/pkg/resource"
 )
 
 const (

--- a/integration/test/event/event_test.go
+++ b/integration/test/event/event_test.go
@@ -15,9 +15,9 @@ import (
 
 	"github.com/giantswarm/microerror"
 
-	"github.com/giantswarm/operatorkit/v6/integration/testresource"
-	"github.com/giantswarm/operatorkit/v6/integration/wrapper/configmap"
-	"github.com/giantswarm/operatorkit/v6/pkg/resource"
+	"github.com/giantswarm/operatorkit/v7/integration/testresource"
+	"github.com/giantswarm/operatorkit/v7/integration/wrapper/configmap"
+	"github.com/giantswarm/operatorkit/v7/pkg/resource"
 )
 
 const (

--- a/integration/test/finalizer/finalizer_test.go
+++ b/integration/test/finalizer/finalizer_test.go
@@ -18,9 +18,9 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/operatorkit/v6/integration/testresource"
-	"github.com/giantswarm/operatorkit/v6/integration/wrapper/configmap"
-	"github.com/giantswarm/operatorkit/v6/pkg/resource"
+	"github.com/giantswarm/operatorkit/v7/integration/testresource"
+	"github.com/giantswarm/operatorkit/v7/integration/wrapper/configmap"
+	"github.com/giantswarm/operatorkit/v7/pkg/resource"
 )
 
 const (

--- a/integration/test/parallel/parallel_test.go
+++ b/integration/test/parallel/parallel_test.go
@@ -17,9 +17,9 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/operatorkit/v6/integration/testresource"
-	"github.com/giantswarm/operatorkit/v6/integration/wrapper/configmap"
-	"github.com/giantswarm/operatorkit/v6/pkg/resource"
+	"github.com/giantswarm/operatorkit/v7/integration/testresource"
+	"github.com/giantswarm/operatorkit/v7/integration/wrapper/configmap"
+	"github.com/giantswarm/operatorkit/v7/pkg/resource"
 )
 
 const (

--- a/integration/test/pause/pause_test.go
+++ b/integration/test/pause/pause_test.go
@@ -14,10 +14,10 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/operatorkit/v6/integration/testresource"
-	"github.com/giantswarm/operatorkit/v6/integration/wrapper"
-	"github.com/giantswarm/operatorkit/v6/integration/wrapper/configmap"
-	"github.com/giantswarm/operatorkit/v6/pkg/resource"
+	"github.com/giantswarm/operatorkit/v7/integration/testresource"
+	"github.com/giantswarm/operatorkit/v7/integration/wrapper"
+	"github.com/giantswarm/operatorkit/v7/integration/wrapper/configmap"
+	"github.com/giantswarm/operatorkit/v7/pkg/resource"
 )
 
 const (

--- a/integration/test/reconciliation/reconciliation_test.go
+++ b/integration/test/reconciliation/reconciliation_test.go
@@ -15,10 +15,10 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/operatorkit/v6/integration/testresource"
-	"github.com/giantswarm/operatorkit/v6/integration/wrapper"
-	"github.com/giantswarm/operatorkit/v6/integration/wrapper/configmap"
-	"github.com/giantswarm/operatorkit/v6/pkg/resource"
+	"github.com/giantswarm/operatorkit/v7/integration/testresource"
+	"github.com/giantswarm/operatorkit/v7/integration/wrapper"
+	"github.com/giantswarm/operatorkit/v7/integration/wrapper/configmap"
+	"github.com/giantswarm/operatorkit/v7/pkg/resource"
 )
 
 const (

--- a/integration/test/statusupdate/resource.go
+++ b/integration/test/statusupdate/resource.go
@@ -16,8 +16,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	v1 "github.com/giantswarm/operatorkit/v6/api/v1"
-	"github.com/giantswarm/operatorkit/v6/integration/env"
+	v1 "github.com/giantswarm/operatorkit/v7/api/v1"
+	"github.com/giantswarm/operatorkit/v7/integration/env"
 )
 
 const (

--- a/integration/test/statusupdate/status_update_test.go
+++ b/integration/test/statusupdate/status_update_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/giantswarm/microerror"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	v1 "github.com/giantswarm/operatorkit/v6/api/v1"
-	"github.com/giantswarm/operatorkit/v6/integration/wrapper/example"
-	"github.com/giantswarm/operatorkit/v6/pkg/resource"
+	v1 "github.com/giantswarm/operatorkit/v7/api/v1"
+	"github.com/giantswarm/operatorkit/v7/integration/wrapper/example"
+	"github.com/giantswarm/operatorkit/v7/pkg/resource"
 )
 
 const (

--- a/integration/wrapper/configmap/wrapper.go
+++ b/integration/wrapper/configmap/wrapper.go
@@ -15,9 +15,9 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/giantswarm/operatorkit/v6/integration/env"
-	"github.com/giantswarm/operatorkit/v6/pkg/controller"
-	"github.com/giantswarm/operatorkit/v6/pkg/resource"
+	"github.com/giantswarm/operatorkit/v7/integration/env"
+	"github.com/giantswarm/operatorkit/v7/pkg/controller"
+	"github.com/giantswarm/operatorkit/v7/pkg/resource"
 )
 
 type Config struct {

--- a/integration/wrapper/example/crud.go
+++ b/integration/wrapper/example/crud.go
@@ -9,7 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	v1 "github.com/giantswarm/operatorkit/v6/api/v1"
+	v1 "github.com/giantswarm/operatorkit/v7/api/v1"
 )
 
 func (w Wrapper) CreateObject(ctx context.Context, namespace string, obj interface{}) (interface{}, error) {

--- a/integration/wrapper/example/wrapper.go
+++ b/integration/wrapper/example/wrapper.go
@@ -17,10 +17,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
-	v1 "github.com/giantswarm/operatorkit/v6/api/v1"
-	"github.com/giantswarm/operatorkit/v6/integration/env"
-	"github.com/giantswarm/operatorkit/v6/pkg/controller"
-	"github.com/giantswarm/operatorkit/v6/pkg/resource"
+	v1 "github.com/giantswarm/operatorkit/v7/api/v1"
+	"github.com/giantswarm/operatorkit/v7/integration/env"
+	"github.com/giantswarm/operatorkit/v7/pkg/controller"
+	"github.com/giantswarm/operatorkit/v7/pkg/resource"
 )
 
 type Config struct {

--- a/integration/wrapper/spec.go
+++ b/integration/wrapper/spec.go
@@ -3,7 +3,7 @@ package wrapper
 import (
 	"context"
 
-	"github.com/giantswarm/operatorkit/v6/pkg/controller"
+	"github.com/giantswarm/operatorkit/v7/pkg/controller"
 )
 
 type Interface interface {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -31,15 +31,15 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	"github.com/giantswarm/operatorkit/v6/pkg/controller/collector"
-	"github.com/giantswarm/operatorkit/v6/pkg/controller/context/cachekeycontext"
-	"github.com/giantswarm/operatorkit/v6/pkg/controller/context/finalizerskeptcontext"
-	"github.com/giantswarm/operatorkit/v6/pkg/controller/context/reconciliationcanceledcontext"
-	"github.com/giantswarm/operatorkit/v6/pkg/controller/context/resourcecanceledcontext"
-	"github.com/giantswarm/operatorkit/v6/pkg/controller/context/updateallowedcontext"
-	"github.com/giantswarm/operatorkit/v6/pkg/controller/internal/recorder"
-	"github.com/giantswarm/operatorkit/v6/pkg/controller/internal/sentry"
-	"github.com/giantswarm/operatorkit/v6/pkg/resource"
+	"github.com/giantswarm/operatorkit/v7/pkg/controller/collector"
+	"github.com/giantswarm/operatorkit/v7/pkg/controller/context/cachekeycontext"
+	"github.com/giantswarm/operatorkit/v7/pkg/controller/context/finalizerskeptcontext"
+	"github.com/giantswarm/operatorkit/v7/pkg/controller/context/reconciliationcanceledcontext"
+	"github.com/giantswarm/operatorkit/v7/pkg/controller/context/resourcecanceledcontext"
+	"github.com/giantswarm/operatorkit/v7/pkg/controller/context/updateallowedcontext"
+	"github.com/giantswarm/operatorkit/v7/pkg/controller/internal/recorder"
+	"github.com/giantswarm/operatorkit/v7/pkg/controller/internal/sentry"
+	"github.com/giantswarm/operatorkit/v7/pkg/resource"
 )
 
 const (

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -13,7 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/giantswarm/operatorkit/v6/pkg/resource"
+	"github.com/giantswarm/operatorkit/v7/pkg/resource"
 )
 
 func Test_Controller_Collector_Register(t *testing.T) {

--- a/pkg/controller/finalizer.go
+++ b/pkg/controller/finalizer.go
@@ -13,7 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/giantswarm/operatorkit/v6/pkg/controller/context/finalizerskeptcontext"
+	"github.com/giantswarm/operatorkit/v7/pkg/controller/context/finalizerskeptcontext"
 )
 
 const (

--- a/pkg/controller/internal/name/name.go
+++ b/pkg/controller/internal/name/name.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/giantswarm/operatorkit/v6/pkg/handler"
+	"github.com/giantswarm/operatorkit/v7/pkg/handler"
 )
 
 func Name(r handler.Interface) string {

--- a/pkg/controller/internal/name/name_test.go
+++ b/pkg/controller/internal/name/name_test.go
@@ -4,10 +4,10 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/giantswarm/operatorkit/v6/pkg/controller/internal/test/handler/bar"
-	"github.com/giantswarm/operatorkit/v6/pkg/controller/internal/test/handler/foo"
-	"github.com/giantswarm/operatorkit/v6/pkg/controller/internal/test/handler/nopointer"
-	"github.com/giantswarm/operatorkit/v6/pkg/handler"
+	"github.com/giantswarm/operatorkit/v7/pkg/controller/internal/test/handler/bar"
+	"github.com/giantswarm/operatorkit/v7/pkg/controller/internal/test/handler/foo"
+	"github.com/giantswarm/operatorkit/v7/pkg/controller/internal/test/handler/nopointer"
+	"github.com/giantswarm/operatorkit/v7/pkg/handler"
 )
 
 func Test_Handler_Name(t *testing.T) {

--- a/pkg/controller/internal/test/handler/bar/handler.go
+++ b/pkg/controller/internal/test/handler/bar/handler.go
@@ -3,7 +3,7 @@ package bar
 import (
 	"context"
 
-	"github.com/giantswarm/operatorkit/v6/pkg/handler"
+	"github.com/giantswarm/operatorkit/v7/pkg/handler"
 )
 
 type Handler struct{}

--- a/pkg/controller/internal/test/handler/foo/handler.go
+++ b/pkg/controller/internal/test/handler/foo/handler.go
@@ -3,7 +3,7 @@ package foo
 import (
 	"context"
 
-	"github.com/giantswarm/operatorkit/v6/pkg/handler"
+	"github.com/giantswarm/operatorkit/v7/pkg/handler"
 )
 
 type Handler struct{}

--- a/pkg/controller/internal/test/handler/nopointer/handler.go
+++ b/pkg/controller/internal/test/handler/nopointer/handler.go
@@ -3,7 +3,7 @@ package nopointer
 import (
 	"context"
 
-	"github.com/giantswarm/operatorkit/v6/pkg/handler"
+	"github.com/giantswarm/operatorkit/v7/pkg/handler"
 )
 
 type Handler struct{}

--- a/pkg/flag/service/kubernetes/kubernetes.go
+++ b/pkg/flag/service/kubernetes/kubernetes.go
@@ -1,8 +1,8 @@
 package kubernetes
 
 import (
-	"github.com/giantswarm/operatorkit/v6/pkg/flag/service/kubernetes/tls"
-	"github.com/giantswarm/operatorkit/v6/pkg/flag/service/kubernetes/watch"
+	"github.com/giantswarm/operatorkit/v7/pkg/flag/service/kubernetes/tls"
+	"github.com/giantswarm/operatorkit/v7/pkg/flag/service/kubernetes/watch"
 )
 
 // Kubernetes is a data structure to hold Kubernetes specific command line

--- a/pkg/resource/crud/resource.go
+++ b/pkg/resource/crud/resource.go
@@ -7,8 +7,8 @@ import (
 	"github.com/giantswarm/micrologger"
 	"github.com/giantswarm/micrologger/loggermeta"
 
-	"github.com/giantswarm/operatorkit/v6/pkg/controller/context/reconciliationcanceledcontext"
-	"github.com/giantswarm/operatorkit/v6/pkg/controller/context/resourcecanceledcontext"
+	"github.com/giantswarm/operatorkit/v7/pkg/controller/context/reconciliationcanceledcontext"
+	"github.com/giantswarm/operatorkit/v7/pkg/controller/context/resourcecanceledcontext"
 )
 
 type ResourceConfig struct {

--- a/pkg/resource/crud/resource_test.go
+++ b/pkg/resource/crud/resource_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/giantswarm/micrologger/microloggertest"
 
-	"github.com/giantswarm/operatorkit/v6/pkg/resource"
+	"github.com/giantswarm/operatorkit/v7/pkg/resource"
 )
 
 func Test_Resource_CRUD_Interface(t *testing.T) {

--- a/pkg/resource/k8s/configmapresource/patch.go
+++ b/pkg/resource/k8s/configmapresource/patch.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/giantswarm/microerror"
 
-	"github.com/giantswarm/operatorkit/v6/pkg/resource/crud"
+	"github.com/giantswarm/operatorkit/v7/pkg/resource/crud"
 )
 
 func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*crud.Patch, error) {

--- a/pkg/resource/k8s/secretresource/patch.go
+++ b/pkg/resource/k8s/secretresource/patch.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/giantswarm/microerror"
 
-	"github.com/giantswarm/operatorkit/v6/pkg/resource/crud"
+	"github.com/giantswarm/operatorkit/v7/pkg/resource/crud"
 )
 
 func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*crud.Patch, error) {

--- a/pkg/resource/wrapper/internal/crud.go
+++ b/pkg/resource/wrapper/internal/crud.go
@@ -1,8 +1,8 @@
 package internal
 
 import (
-	"github.com/giantswarm/operatorkit/v6/pkg/resource"
-	"github.com/giantswarm/operatorkit/v6/pkg/resource/crud"
+	"github.com/giantswarm/operatorkit/v7/pkg/resource"
+	"github.com/giantswarm/operatorkit/v7/pkg/resource/crud"
 )
 
 func CRUD(r resource.Interface) (crud.Interface, bool) {

--- a/pkg/resource/wrapper/internal/crud_test.go
+++ b/pkg/resource/wrapper/internal/crud_test.go
@@ -3,7 +3,7 @@ package internal
 import (
 	"testing"
 
-	"github.com/giantswarm/operatorkit/v6/pkg/resource/wrapper/internal/test"
+	"github.com/giantswarm/operatorkit/v7/pkg/resource/wrapper/internal/test"
 )
 
 func Test_CRUD_success(t *testing.T) {

--- a/pkg/resource/wrapper/internal/test/nop_crud.go
+++ b/pkg/resource/wrapper/internal/test/nop_crud.go
@@ -3,7 +3,7 @@ package test
 import (
 	"context"
 
-	"github.com/giantswarm/operatorkit/v6/pkg/resource/crud"
+	"github.com/giantswarm/operatorkit/v7/pkg/resource/crud"
 )
 
 type NopCRUD struct {

--- a/pkg/resource/wrapper/internal/test/nop_crud_resource.go
+++ b/pkg/resource/wrapper/internal/test/nop_crud_resource.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/giantswarm/micrologger/microloggertest"
 
-	"github.com/giantswarm/operatorkit/v6/pkg/resource"
-	"github.com/giantswarm/operatorkit/v6/pkg/resource/crud"
+	"github.com/giantswarm/operatorkit/v7/pkg/resource"
+	"github.com/giantswarm/operatorkit/v7/pkg/resource/crud"
 )
 
 func NewNopCRUDResource() resource.Interface {

--- a/pkg/resource/wrapper/metricsresource/basic_resource.go
+++ b/pkg/resource/wrapper/metricsresource/basic_resource.go
@@ -6,7 +6,7 @@ import (
 	"github.com/giantswarm/microerror"
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/giantswarm/operatorkit/v6/pkg/resource"
+	"github.com/giantswarm/operatorkit/v7/pkg/resource"
 )
 
 type basicResourceConfig struct {

--- a/pkg/resource/wrapper/metricsresource/crud_resource.go
+++ b/pkg/resource/wrapper/metricsresource/crud_resource.go
@@ -6,7 +6,7 @@ import (
 	"github.com/giantswarm/microerror"
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/giantswarm/operatorkit/v6/pkg/resource/crud"
+	"github.com/giantswarm/operatorkit/v7/pkg/resource/crud"
 )
 
 type crudResourceConfig struct {

--- a/pkg/resource/wrapper/metricsresource/metrics_resource.go
+++ b/pkg/resource/wrapper/metricsresource/metrics_resource.go
@@ -4,9 +4,9 @@ import (
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger/microloggertest"
 
-	"github.com/giantswarm/operatorkit/v6/pkg/resource"
-	"github.com/giantswarm/operatorkit/v6/pkg/resource/crud"
-	"github.com/giantswarm/operatorkit/v6/pkg/resource/wrapper/internal"
+	"github.com/giantswarm/operatorkit/v7/pkg/resource"
+	"github.com/giantswarm/operatorkit/v7/pkg/resource/crud"
+	"github.com/giantswarm/operatorkit/v7/pkg/resource/wrapper/internal"
 )
 
 type Config struct {

--- a/pkg/resource/wrapper/metricsresource/metrics_resource_test.go
+++ b/pkg/resource/wrapper/metricsresource/metrics_resource_test.go
@@ -3,8 +3,8 @@ package metricsresource
 import (
 	"testing"
 
-	"github.com/giantswarm/operatorkit/v6/pkg/resource/wrapper/internal"
-	"github.com/giantswarm/operatorkit/v6/pkg/resource/wrapper/internal/test"
+	"github.com/giantswarm/operatorkit/v7/pkg/resource/wrapper/internal"
+	"github.com/giantswarm/operatorkit/v7/pkg/resource/wrapper/internal/test"
 )
 
 // Test_CRUD_success tests if wrapping CRUD resource allows extracting

--- a/pkg/resource/wrapper/metricsresource/wrap.go
+++ b/pkg/resource/wrapper/metricsresource/wrap.go
@@ -3,7 +3,7 @@ package metricsresource
 import (
 	"github.com/giantswarm/microerror"
 
-	"github.com/giantswarm/operatorkit/v6/pkg/resource"
+	"github.com/giantswarm/operatorkit/v7/pkg/resource"
 )
 
 // WrapConfig is the configuration used to wrap resources with metrics resources.

--- a/pkg/resource/wrapper/retryresource/basic_resource.go
+++ b/pkg/resource/wrapper/retryresource/basic_resource.go
@@ -8,7 +8,7 @@ import (
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 
-	"github.com/giantswarm/operatorkit/v6/pkg/resource"
+	"github.com/giantswarm/operatorkit/v7/pkg/resource"
 )
 
 type basicResourceConfig struct {

--- a/pkg/resource/wrapper/retryresource/crud_resource.go
+++ b/pkg/resource/wrapper/retryresource/crud_resource.go
@@ -8,7 +8,7 @@ import (
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 
-	"github.com/giantswarm/operatorkit/v6/pkg/resource/crud"
+	"github.com/giantswarm/operatorkit/v7/pkg/resource/crud"
 )
 
 type crudResourceConfig struct {

--- a/pkg/resource/wrapper/retryresource/retry_resource.go
+++ b/pkg/resource/wrapper/retryresource/retry_resource.go
@@ -5,9 +5,9 @@ import (
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 
-	"github.com/giantswarm/operatorkit/v6/pkg/resource"
-	"github.com/giantswarm/operatorkit/v6/pkg/resource/crud"
-	"github.com/giantswarm/operatorkit/v6/pkg/resource/wrapper/internal"
+	"github.com/giantswarm/operatorkit/v7/pkg/resource"
+	"github.com/giantswarm/operatorkit/v7/pkg/resource/crud"
+	"github.com/giantswarm/operatorkit/v7/pkg/resource/wrapper/internal"
 )
 
 type Config struct {

--- a/pkg/resource/wrapper/retryresource/retry_resource_test.go
+++ b/pkg/resource/wrapper/retryresource/retry_resource_test.go
@@ -6,8 +6,8 @@ import (
 	"github.com/giantswarm/backoff"
 	"github.com/giantswarm/micrologger/microloggertest"
 
-	"github.com/giantswarm/operatorkit/v6/pkg/resource/wrapper/internal"
-	"github.com/giantswarm/operatorkit/v6/pkg/resource/wrapper/internal/test"
+	"github.com/giantswarm/operatorkit/v7/pkg/resource/wrapper/internal"
+	"github.com/giantswarm/operatorkit/v7/pkg/resource/wrapper/internal/test"
 )
 
 // Test_CRUD_success tests if wrapping CRUD resource allows extracting

--- a/pkg/resource/wrapper/retryresource/wrap.go
+++ b/pkg/resource/wrapper/retryresource/wrap.go
@@ -7,7 +7,7 @@ import (
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 
-	"github.com/giantswarm/operatorkit/v6/pkg/resource"
+	"github.com/giantswarm/operatorkit/v7/pkg/resource"
 )
 
 // WrapConfig is the configuration used to wrap resources with retry resources.


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/20186

Bumping major version here due to dependecies changing major version too.

- Upgrade github.com/giantswarm/backoff v0.2.0 to v1.0.0
- Upgrade github.com/giantswarm/exporterkit v0.2.1 to v1.0.0
- Upgrade github.com/giantswarm/k8sclient v6.0.0 to v7.0.0