### PR TITLE
Include controller name as label in reconcileErrors metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Change Reconcile errors total to include controller name. 
+
 ## [7.0.1] - 2022-02-07
 
 ### Changed

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -321,7 +321,7 @@ func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	if err != nil {
 		// Microerror creates an error event on the object when kind and description is set.
 		c.event.Emit(ctx, obj, err)
-		errorGauge.Inc()
+		reconcileErrors.WithLabelValues(c.name).Inc()
 		c.sentry.Capture(ctx, err)
 		c.logger.Errorf(ctx, err, "failed to reconcile")
 		return reconcile.Result{}, nil
@@ -347,7 +347,7 @@ func (c *Controller) bootWithError(ctx context.Context) error {
 		for {
 			resetWait := c.resyncPeriod * 4
 			time.Sleep(resetWait)
-			errorGauge.Set(0)
+			reconcileErrors.WithLabelValues(c.name).Set(0)
 		}
 	}()
 
@@ -366,7 +366,7 @@ func (c *Controller) bootWithError(ctx context.Context) error {
 					return
 				}
 
-				errorGauge.Inc()
+				reconcileErrors.WithLabelValues(c.name).Inc()
 				c.logger.Errorf(ctx, err, "caught third party runtime error")
 			},
 		}

--- a/pkg/controller/metric.go
+++ b/pkg/controller/metric.go
@@ -10,14 +10,15 @@ const (
 )
 
 var (
-	errorGauge = prometheus.NewGauge(
-		prometheus.GaugeOpts{
-			Namespace: PrometheusNamespace,
-			Subsystem: PrometheusSubsystem,
-			Name:      "error_total",
-			Help:      "Number of reconciliation errors.",
-		},
-	)
+	// ReconcileErrors is a prometheus counter metrics which holds the total
+	// number of errors from the Reconciler.
+	reconcileErrors = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: PrometheusNamespace,
+		Subsystem: PrometheusSubsystem,
+		Name:      "errors_total",
+		Help:      "Total number of reconciliation errors per controller",
+	}, []string{"controller"})
+
 	eventHistogram = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Namespace: PrometheusNamespace,
@@ -39,7 +40,7 @@ var (
 )
 
 func init() {
-	prometheus.MustRegister(errorGauge)
+	prometheus.MustRegister(reconcileErrors)
 	prometheus.MustRegister(eventHistogram)
 	prometheus.MustRegister(lastReconciledGauge)
 }


### PR DESCRIPTION
Currently `operatorkit_controller_error_total` doesn't include the name of the controller associated.
in [PMO](https://github.com/giantswarm/prometheus-meta-operator) we have many controllers bundled.

We need to distinguish total errors per controller, to build alerts

## Checklist

- [X] Update changelog in CHANGELOG.md.
- [ ] Update roadmap in ROADMAP.md.
